### PR TITLE
arch:all packages don't need ${shlibs:Depends}

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/mika/jenkins-debian-glue
 
 Package: jenkins-debian-glue
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, cowbuilder, devscripts, dpkg-dev, reprepro, sudo
+Depends: ${misc:Depends}, cowbuilder, devscripts, dpkg-dev, reprepro, sudo
 Description: glue scripts for building Debian packages inside Jenkins
  This package provides scripts which should make building Debian
  package inside Jenkins (a Continuous Integration suite) easier.
@@ -20,7 +20,7 @@ Description: glue scripts for building Debian packages inside Jenkins
 
 Package: jenkins-debian-glue-buildenv-git
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, git-buildpackage, jenkins-debian-glue, pristine-tar
+Depends: ${misc:Depends}, build-essential, git-buildpackage, jenkins-debian-glue, pristine-tar
 Description: virtual package for Git build environment of jenkins-debian-glue
  This virtual packages depends on the software packages required
  for using jenkins-debian-glue as standalone build environment
@@ -28,7 +28,7 @@ Description: virtual package for Git build environment of jenkins-debian-glue
 
 Package: jenkins-debian-glue-buildenv-svn
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, jenkins-debian-glue, subversion-tools, xsltproc
+Depends: ${misc:Depends}, build-essential, jenkins-debian-glue, subversion-tools, xsltproc
 Description: virtual package for Subversion build environment of jenkins-debian-glue
  This virtual packages depends on the software packages required
  for using jenkins-debian-glue as standalone build environment
@@ -36,14 +36,14 @@ Description: virtual package for Subversion build environment of jenkins-debian-
 
 Package: jenkins-debian-glue-buildenv-slave
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, build-essential, jenkins-debian-glue, rsync, openjdk-6-jre-headless | sun-java6-jre | java-runtime-headless
+Depends: ${misc:Depends}, build-essential, jenkins-debian-glue, rsync, openjdk-6-jre-headless | sun-java6-jre | java-runtime-headless
 Description: virtual package for basic build environment of jenkins-debian-glue
  This virtual packages depends on the software packages required
  for using jenkins-debian-glue on a slave system inside Jenkins.
 
 Package: jenkins-debian-glue-buildenv-lintian
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lintian, ruby
+Depends: ${misc:Depends}, lintian, ruby
 Description: lintian integration in Jenkins
  This package provides the lintian-junit-report script. The
  script can be used for generating JUnit reports of lintian


### PR DESCRIPTION
Fixes dpkg-gencontrol warning "Depends field of package jenkins-debian-glue...: unknown substitution variable ${shlibs:Depends}".
