### PR TITLE
Adding support to override git-buildpackage options

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: cowbuilder,
          devscripts,
          dpkg-dev,
          reprepro,
-         sudo,
+         sudo | sudo-ldap,
          ${misc:Depends}
 Description: glue scripts for building Debian packages inside Jenkins
  This package provides scripts which should make building Debian


### PR DESCRIPTION
I have a specific need to have my package names not include the git commit $ID. Adding git-buildpackage options you can get around this by removing the -S.

Thanks again for all your work on this! 
