### PR TITLE
Depends of sudo or sudo-ldap

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: cowbuilder,
          devscripts,
          dpkg-dev,
          reprepro,
-         sudo,
+         sudo | sudo-ldap,
          ${misc:Depends}
 Description: glue scripts for building Debian packages inside Jenkins
  This package provides scripts which should make building Debian


### PR DESCRIPTION
In Debian 6 it's now impossible install jenkins-debian-glue.deb when sudo-ldap is installed (sudo-ldap will be replaced with sudo). My suggestion is depend of sudo or sudo-ldap
