### PR TITLE
Allow Setting all reprepro directories

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -17,3 +17,18 @@
 # packages will be build then.
 # If unset it will default to the architecture of the host system.
 # MAIN_ARCHITECTURE="amd64"
+
+# The reprepro repository
+# Defaults:
+# REPOSITORY='/srv/repository'
+
+# You can define every reprepro directory separately.
+# $REPOSITORY is used as the base directory (+b)
+# Defaults:
+# REPOSITORY_OUT_DIR='+b'
+# REPOSITORY_CONF_DIR='+b/conf'
+# REPOSITORY_DIST_DIR='+o/dists'
+# REPOSITORY_LOG_DIR='+b/logs'
+# REPOSITORY_DB_DIR='+b/db'
+# REPOSITORY_LIST_DIR='+b/lists'
+# REPOSITORY_MORGUE_DIR='+b/morgue'

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -33,6 +33,36 @@ checks_and_defaults() {
   if [ -z "${REPOSITORY:-}" ] ; then
     REPOSITORY='/srv/repository'
   fi
+
+  if [ -z "${REPOSITORY_OUT_DIR:-}" ] ; then
+    REPOSITORY_OUT_DIR='+b'
+  fi
+
+  if [ -z "${REPOSITORY_CONF_DIR:-}" ] ; then
+    REPOSITORY_CONF_DIR='+b/conf'
+  fi
+
+  if [ -z "${REPOSITORY_DIST_DIR:-}" ] ; then
+    REPOSITORY_DIST_DIR='+o/dists'
+  fi
+
+  if [ -z "${REPOSITORY_LOG_DIR:-}" ] ; then
+    REPOSITORY_LOG_DIR='+b/logs'
+  fi
+
+  if [ -z "${REPOSITORY_DB_DIR:-}" ] ; then
+    REPOSITORY_DB_DIR='+b/db'
+  fi
+
+  if [ -z "${REPOSITORY_LIST_DIR:-}" ] ; then
+    REPOSITORY_LIST_DIR='+b/lists'
+  fi
+
+  if [ -z "${REPOSITORY_MORGUE_DIR:-}" ] ; then
+    REPOSITORY_MORGUE_DIR='+b/morgue'
+  fi
+
+  REPREPRO_DIRS=`echo -e --basedir "${REPOSITORY}" --outdir "${REPOSITORY_OUT_DIR}" --distdir "${REPOSITORY_DIST_DIR}" --confdir "${REPOSITORY_CONF_DIR}" --logdir "${REPOSITORY_LOG_DIR}" --dbdir "${REPOSITORY_DB_DIR}" --listdir "${REPOSITORY_LIST_DIR}" --morguedir "${REPOSITORY_MORGUE_DIR}"`
 }
 
 clean_workspace() {
@@ -302,7 +332,7 @@ remove_packages() {
   fi
 
   echo "*** Removing source package version from repository ***"
-  ${SUDO_CMD:-} reprepro -v -A source -b "${REPOSITORY}" --waitforlock 1000 remove "${REPOS}" "${SOURCE_PACKAGE}"
+  ${SUDO_CMD:-} reprepro -v -A source ${REPREPRO_DIRS} --waitforlock 1000 remove "${REPOS}" "${SOURCE_PACKAGE}"
 
   echo "*** Removing previous binary package versions from repository ***"
   for p in $(dcmd "${WORKSPACE}/binaries/"*"${newest_version}_${arch}.changes" | grep '\.deb$') ; do
@@ -313,10 +343,10 @@ remove_packages() {
     # note: "removesrc" would remove foreign arch files (of different builds)
     if echo "$file" | egrep -q '_all.deb$'; then
       echo "*** Removing existing package ${binpackage} from repository ${REPOS} (arch all) ***"
-      ${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 remove "${REPOS}" "${binpackage}"
+      ${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 remove "${REPOS}" "${binpackage}"
     else
       echo "*** Removing existing package ${binpackage} from repository ${REPOS} for arch ${arch} ***"
-      ${SUDO_CMD:-} reprepro -v -A "${arch}" -b "${REPOSITORY}" --waitforlock 1000 remove "${REPOS}" "${binpackage}"
+      ${SUDO_CMD:-} reprepro -v -A "${arch}" ${REPREPRO_DIRS} --waitforlock 1000 remove "${REPOS}" "${binpackage}"
     fi
 
   done
@@ -343,7 +373,7 @@ remove_missing_binary_packages() {
       ;;
   esac
 
-  for p in $(${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 --list-format '${package}\n' listmatched "${REPOS}" '*' | sort -u); do
+  for p in $(${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 --list-format '${package}\n' listmatched "${REPOS}" '*' | sort -u); do
     echo " $binary_list " | grep -q " $p " || missing_packages="${missing_packages:-} $p"
   done
 
@@ -352,7 +382,7 @@ remove_missing_binary_packages() {
 
     for p in $missing_packages ; do
       echo "*** Removing $p from $REPOS to avoid out-of-date data ***"
-      ${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 remove "${REPOS}" "${p}"
+      ${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 remove "${REPOS}" "${p}"
     done
   fi
 }
@@ -375,7 +405,7 @@ reprepro_wrapper() {
   esac
 
   echo "*** Including packages in repository $REPOS ***"
-  ${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 --ignore=wrongdistribution \
+  ${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 --ignore=wrongdistribution \
     include "${REPOS}" "${WORKSPACE}/binaries/"*"${newest_version}"_${architecture}.changes
   [ $? -eq 0 ] || bailout 1 "Error: Failed to include binary package in $REPOS repository."
 }
@@ -392,7 +422,7 @@ trunk_release() {
 
     ${SUDO_CMD:-} generate-reprepro-codename "$TRUNK_RELEASE"
 
-    ${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 --ignore=wrongdistribution copymatched "$TRUNK_RELEASE" "$REPOS" '*'
+    ${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 --ignore=wrongdistribution copymatched "$TRUNK_RELEASE" "$REPOS" '*'
     [ $? -eq 0 ] || bailout 1 "Error: Failed to copy packages from ${REPOS} to ${TRUNK_RELEASE}."
   fi
 }
@@ -400,15 +430,13 @@ trunk_release() {
 release_repos() {
   echo "*** Environment variable 'release' is set, running through release steps. ***"
 
-  local REPOSITORY="${REPOSITORY}/release/${release}"
-
   mkdir -p "${REPOSITORY}/incoming/${release}"
   mkdir -p "${REPOSITORY}/conf"
 
   cp "${WORKSPACE}/binaries/"* "${REPOSITORY}/incoming/${release}/"
   [ $? -eq 0 ] || bailout 1 "Error: Failed to copy binary packages to release directory."
 
-  REPOSITORY=$REPOSITORY generate-reprepro-codename "${release}"
+  generate-reprepro-codename "${release}"
 
   if ! grep -q "^Name: $release$" "${REPOSITORY}/conf/incoming" 2>/dev/null ; then
     cat >> "${REPOSITORY}/conf/incoming" << EOF
@@ -426,7 +454,7 @@ EOF
 
   local old_dir=$(pwd)
   cd "${REPOSITORY}/incoming/${release}"
-  ${SUDO_CMD:-} reprepro -v -b "${REPOSITORY}" --waitforlock 1000 --ignore=wrongdistribution \
+  ${SUDO_CMD:-} reprepro -v ${REPREPRO_DIRS} --waitforlock 1000 --ignore=wrongdistribution \
                 processincoming "${release}" "$(basename ${WORKSPACE}/binaries/*.changes)"
   local RC=$?
   cd "$old_dir"

--- a/scripts/repository_checker
+++ b/scripts/repository_checker
@@ -11,9 +11,39 @@ if [ -z "${REPOSITORY:-}" ] ; then
   REPOSITORY='/srv/repository'
 fi
 
+if [ -z "${REPOSITORY_OUT_DIR:-}" ] ; then
+  REPOSITORY_OUT_DIR='+b'
+fi
+
+if [ -z "${REPOSITORY_CONF_DIR:-}" ] ; then
+  REPOSITORY_CONF_DIR='+b/conf'
+fi
+
+if [ -z "${REPOSITORY_DIST_DIR:-}" ] ; then
+  REPOSITORY_DIST_DIR='+o/dists'
+fi
+
+if [ -z "${REPOSITORY_LOG_DIR:-}" ] ; then
+  REPOSITORY_LOG_DIR='+b/logs'
+fi
+
+if [ -z "${REPOSITORY_DB_DIR:-}" ] ; then
+  REPOSITORY_DB_DIR='+b/db'
+fi
+
+if [ -z "${REPOSITORY_LIST_DIR:-}" ] ; then
+  REPOSITORY_LIST_DIR='+b/lists'
+fi
+
+if [ -z "${REPOSITORY_MORGUE_DIR:-}" ] ; then
+  REPOSITORY_MORGUE_DIR='+b/morgue'
+fi
+
 if [ -z "${REPREPRO_OPTS:-}" ]  ; then
   REPREPRO_OPTS='--waitforlock 1000 -v'
 fi
+
+REPREPRO_DIRS=`echo -e --basedir "${REPOSITORY}" --outdir "${REPOSITORY_OUT_DIR}" --distdir "${REPOSITORY_DIST_DIR}" --confdir "${REPOSITORY_CONF_DIR}" --logdir "${REPOSITORY_LOG_DIR}" --dbdir "${REPOSITORY_DB_DIR}" --listdir "${REPOSITORY_LIST_DIR}" --morguedir "${REPOSITORY_MORGUE_DIR}"`
 
 LOGFILE=$(mktemp)
 
@@ -86,10 +116,10 @@ validate-source-bin-versions() {
   rc=0
 
   for repository in $(awk '/^Codename: / {print $2}' "${REPOSITORY}"/conf/distributions 2>"${LOGFILE}") ; do
-    for sourcepackage in $(reprepro $REPREPRO_OPTS -A source -b "${REPOSITORY}" --list-format='${package}\n' list $repository 2>"${LOGFILE}") ; do
-      sourceversion=$(reprepro $REPREPRO_OPTS -A source -b "${REPOSITORY}" --list-format='${version}\n' list $repository $sourcepackage 2>"${LOGFILE}")
-      for binarypackage in $(reprepro $REPREPRO_OPTS -b "${REPOSITORY}" --list-format='${package}\n' -T deb listfilter "$repository" "\$Source (==$sourcepackage)" 2>"${LOGFILE}") ; do
-        archversion=$(reprepro $REPREPRO_OPTS -A amd64 -b "${REPOSITORY}" --list-format='${version}\n' list $repository $binarypackage 2>"${LOGFILE}")
+    for sourcepackage in $(reprepro $REPREPRO_OPTS -A source ${REPREPRO_DIRS} --list-format='${package}\n' list $repository 2>"${LOGFILE}") ; do
+      sourceversion=$(reprepro $REPREPRO_OPTS -A source ${REPREPRO_DIRS} --list-format='${version}\n' list $repository $sourcepackage 2>"${LOGFILE}")
+      for binarypackage in $(reprepro $REPREPRO_OPTS ${REPREPRO_DIRS} --list-format='${package}\n' -T deb listfilter "$repository" "\$Source (==$sourcepackage)" 2>"${LOGFILE}") ; do
+        archversion=$(reprepro $REPREPRO_OPTS -A amd64 ${REPREPRO_DIRS} --list-format='${version}\n' list $repository $binarypackage 2>"${LOGFILE}")
 
         if [ -z "$archversion" ] && [ -n "$sourceversion" ] ; then
           echo "Warning: package $binarypackage in repository $repository has sourceversion $sourceversion but lacks archversion"
@@ -193,32 +223,32 @@ fi
 
 # main execution
 if $_opt_list_packages ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" ls "${PACKAGE}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} ls "${PACKAGE}"
   bailout 0
 fi
 
 if $_opt_list_source_package ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" -A source ls "${PACKAGE}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} -A source ls "${PACKAGE}"
   bailout 0
 fi
 
 if $_opt_list_binary_package ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" -T deb ls "${PACKAGE}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} -T deb ls "${PACKAGE}"
   bailout 0
 fi
 
 if $_opt_list_repos ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" list "${REPOS}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} list "${REPOS}"
   bailout 0
 fi
 
 if $_opt_list_source_repos ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" -A source list "${REPOS}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} -A source list "${REPOS}"
   bailout 0
 fi
 
 if $_opt_list_binary_repos ; then
-  reprepro ${REPREPRO_OPTS} -b "${REPOSITORY}" -T deb list "${REPOS}"
+  reprepro ${REPREPRO_OPTS} ${REPREPRO_DIRS} -T deb list "${REPOS}"
   bailout 0
 fi
 


### PR DESCRIPTION
Fix - Do not reset REPOSITORY before running generate-reprepro-codename
      If REPOSITORY is overwritten with a release dir, it generates a new rerepro db, and changing REPOSITORY does not take effect. If REPOSITORY was changed to something else generate-reprepro-codename runs into errors, because it do not know about the new overwritten REPOSTIRORY var.
