### PR TITLE
Add UDebComponents. Needed by some packages.

### DIFF
--- a/scripts/generate-reprepro-codename
+++ b/scripts/generate-reprepro-codename
@@ -62,6 +62,7 @@ Codename: ${REPOS}
 AlsoAcceptFor: unstable
 Architectures: amd64 i386 source
 Components: main
+UDebComponents: main
 DebIndices: Packages Release . .gz
 DscIndices: Sources Release .gz
 Tracking: minimal


### PR DESCRIPTION
Some packages provide udebs (mdadm for exmple). In order to put them in reprepro there must be UDebComponents for at least main section.
