### PR TITLE
Add a hook to launch script before the creation of the .dsc 

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -231,6 +231,16 @@ changelog_generation() {
 echo "*** source package build phase ***"
 rm -f ./* || true
 
+if ! [ -z "$PRE_SOURCE_HOOK" ] ; then
+	if ! [ -s "$PRE_SOURCE_HOOK" ]; then
+	    echo "Could not find hook: $PRE_SOURCE_HOOK"
+	    exit 1
+	else
+        echo "Found environment variable PRE_SOURCE_HOOK, set to ${PRE_SOURCE_HOOK}"
+	    sh $PRE_SOURCE_HOOK
+    fi
+fi
+
 cd "$SOURCE_DIRECTORY"
 
 # make sure common branches are available for git-buildpackage

--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -162,8 +162,19 @@ if [ "${debian_only:-}" = "1" ] ; then
      --svn-ignore-new -rfakeroot
   )
 else
-  dpkg-source --tar-ignore=\.svn -b source/${branch:-}
+    if ! [ -z "$PRE_SOURCE_HOOK" ] ; then
+	    if ! [ -s "$PRE_SOURCE_HOOK" ]; then
+	        echo "Could not find hook: $PRE_SOURCE_HOOK"
+	        exit 1
+	    else
+            echo "Found environment variable PRE_SOURCE_HOOK, set to ${PRE_SOURCE_HOOK}"
+	        sh $PRE_SOURCE_HOOK
+        fi
+    fi
+    dpkg-source --tar-ignore=\.svn -b source/${branch:-}
 fi
+
+
 
 # revert to original debian/changelog to avoid highly increasing version numbers with each build
 ( cd source/${branch:-} ; svn revert debian/changelog )


### PR DESCRIPTION
Add the management of a PRE_SOURCE_HOOK variable. If set, the script pointed by PRE_SOURCE_HOOK will be executed before the .dsc creation

If you are interested, I can update the documentation.
