### PR TITLE
Allow removal of packages from releases

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -31,3 +31,9 @@
 # directory set RELEASE_REPOSITORY accordingly.
 # Default:
 # RELEASE_REPOSITORY="${REPOSITORY}/release/${release}"
+
+# Remove packages from a $release before processing incoming
+# This allows to rebuild and provide versions already existent
+# in the release repository they are built for.
+# Default:
+# REMOVE_FROM_RELEASE=false

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -511,6 +511,11 @@ release_repos() {
   mkdir -p "${REPOSITORY}/incoming/${release}"
   mkdir -p "${REPOSITORY}/conf"
 
+  if [ "${REMOVE_FROM_RELEASE}" = 'true' ]; then
+    echo "*** REMOVE_FROM_RELEASE is set, trying to remove package(s) from release repository"
+    REPOS="${release}" remove_packages
+  fi
+
   cp "${WORKSPACE}/binaries/"* "${REPOSITORY}/incoming/${release}/"
   [ $? -eq 0 ] || bailout 1 "Error: Failed to copy binary packages to release directory."
 


### PR DESCRIPTION
By default, if building a package for a release, it is assumed, that
this version has never been part of the release. Thus building the same
version again will fail, since reprepro will not allow adding this.
This patch adds a new option REMOVE_FROM_RELEASE which will force a
removal of the package from a release prior to incoming processing,
which may be useful in some cases (e.g. wanted rebuilds of releases)
