### PR TITLE
Bugfix: Make dpkg-source ignore .git in more cases

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -261,7 +261,7 @@ fi
 
 # build source package, run before switching back to previous branch
 # to get the actual requested version
-( cd .. ; dpkg-source -I -b "$SOURCE_DIRECTORY" )
+( cd .. ; dpkg-source -i -I -b "$SOURCE_DIRECTORY" )
 
 # revert to original debian/changelog to avoid merge conflicts
 git checkout -- $(readlink -f debian/changelog)


### PR DESCRIPTION
In some cases the '-I' param to dpkg-source is not enough. In this case
builds fail since dpkg-source complains about modified files.
This patch additionally adds (previously used) '-i' to the params, which fixes those cases.
