### PR TITLE
Change timestamp format used in version string

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -52,7 +52,7 @@ version_information() {
   # we want to get a version string like
   # $ORIG_VERSION+0~$TIMESTAMP.$BUILD_NUMBER~1.$GIT_ID
   # so the version is always increasing over time, no matter what
-  TIMESTAMP="$(date +%s)" # seconds since 1970-01-01 00:00:00 UTC, reversible via `date -d @$TIMESTAMP`
+  TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
   BUILD_VERSION="${TIMESTAMP}.${BUILD_NUMBER}" # git-dch appends something like ~1.gbp5f433e then
 
   # we do NOT raise the version number, if we detect an unreleased version,

--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -77,7 +77,7 @@ build_snapshot() {
 
   DISTRIBUTION=$(dpkg-parsechangelog --count 1 | awk '/^Distribution/ {print $2}')
 
-  TIMESTAMP=$(date +%s) # seconds since 1970-01-01 00:00:00 UTC, ensuring version gets always newer...
+  TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
 
   if [ "$DISTRIBUTION" = "UNRELEASED" ] ; then
     # we do NOT raise the version number, if we detect an unreleased version


### PR DESCRIPTION
The timestamp YYYYMMDDhhmmss sorts equally well as unix timestamp and
yet it is much more usable for human beings.

This is correct both numerically and lexicographically. And the package built after upgrade to version containing this commit will also be "newer".

Regards,
Slawek
