### PR TITLE
cd to workspace in generate-git-snapshot when running dpkg-source

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -271,7 +271,7 @@ fi
 
 # build source package, run before switching back to previous branch
 # to get the actual requested version
-( cd .. ; dpkg-source -i -I -b "$SOURCE_DIRECTORY" )
+( cd "$WORKSPACE" ; dpkg-source -i -I -b "$SOURCE_DIRECTORY" )
 
 # revert to original debian/changelog to avoid merge conflicts
 git checkout -- $(readlink -f debian/changelog)


### PR DESCRIPTION
Previously, it was doing "cd .." to move up one level, which doesn't
work correctly if $SOURCE_DIRECTORY is multiple levels deep, e.g.
SOURCE_DIRECTORY=source/subproject
