### PR TITLE
Improve the hook scripts

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -232,13 +232,8 @@ echo "*** source package build phase ***"
 rm -f ./* || true
 
 if [ -n "${PRE_SOURCE_HOOK:-}" ] ; then
-  if ! [ -s "${PRE_SOURCE_HOOK:-}" ]; then
-    echo "Error: Could not find hook: ${PRE_SOURCE_HOOK:-}" >&2
-    exit 1
-  else
     echo "*** Found environment variable PRE_SOURCE_HOOK, set to ${PRE_SOURCE_HOOK:-} ***"
-    sh "${PRE_SOURCE_HOOK:-}"
-  fi
+    sh ${PRE_SOURCE_HOOK:-}
 fi
 
 cd "$SOURCE_DIRECTORY"

--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -162,14 +162,9 @@ if [ "${debian_only:-}" = "1" ] ; then
      --svn-ignore-new -rfakeroot
   )
 else
-  if ! [ -z "${PRE_SOURCE_HOOK:-}" ] ; then
-    if ! [ -s "${PRE_SOURCE_HOOK:-}" ]; then
-      echo "Error: Could not find hook: ${PRE_SOURCE_HOOK:-}" >&2
-      exit 1
-    else
+  if [ -n "${PRE_SOURCE_HOOK:-}" ] ; then
       echo "*** Found environment variable PRE_SOURCE_HOOK, set to ${PRE_SOURCE_HOOK:-} ***"
-      sh "${PRE_SOURCE_HOOK:-}"
-    fi
+      sh ${PRE_SOURCE_HOOK:-}
   fi
 
   dpkg-source --tar-ignore=\.svn -b source/${branch:-}


### PR DESCRIPTION
```
* Do not test if the file exist. It blocks the usage of 'export PRE_SOURCE_H
* Match the similar declaration in the git & svn scripts
```
