### PR TITLE
Feature/lintian opt

### DIFF
--- a/scripts/lintian-junit-report
+++ b/scripts/lintian-junit-report
@@ -66,8 +66,8 @@ def usage
   exit(1)
 end
 
-file = ARGV[0]
-usage if file.nil?
+files = ARGV
+usage if files.empty?
 ### }}}
 
 ### make sure lintian is available {{{
@@ -82,7 +82,7 @@ start = Time.now.to_f
 
 lintian_options << "--info" unless options[:disablenotes]
 
-$output = IO.popen(['lintian'] + lintian_options + ['--', file]) do |io|
+$output = IO.popen(['lintian'] + lintian_options + ['--'] + files) do |io|
   io.read
 end
 


### PR DESCRIPTION
Small changes to lintian-junit-report that allows passing arguments to lintian subprocess and make it actually support multiple file names (even those very popular .deb-s that have names starting with dashes and containing spaces ;)).
