### PR TITLE
Improve JUnit report

### DIFF
--- a/scripts/lintian-junit-report
+++ b/scripts/lintian-junit-report
@@ -116,7 +116,7 @@ end
 
 def error_header
   puts %Q[<?xml version="1.0" encoding="UTF-8"?>
-<testsuite name="lintian" tests="#{$lintian_count}" time="1" failures="#{$lintian_count}" errors="0" skipped="0" assertions="0">]
+<testsuite name="lintian" tests="#{$lintian_count}" time="#{$duration}" failures="#{$lintian_count}" errors="0" skipped="0" assertions="0">]
 end
 
 def tc_head(package, note, report_line)
@@ -163,6 +163,10 @@ end
 
 ### write output {{{
 error_header
+
+# As Jenkins shows the total time as the sum of time taken for each test case,
+# blame each case for the time spent evenly
+$duration /= $lintian_count
 
 # For collecting lintian tag descriptions, which are returned only once per
 # issued tag


### PR DESCRIPTION
Now something more complex and probably needing more thorough review. All the commits here are created to make Jenkins test results presentation for lintian more useful. The tests are grouped by package under test and named after lintian tags (+ tag arguments). Ouput from lintian is parsed a bit more in order to attach meaningful part of it to specific test cases. And the final small change fix the problem with time reported as actual lintian run time multiplied by number of failing test cases.

Oh, and this time I've also checked it with Ruby 1.8 (that is 1.8.7).
