### PR TITLE
Add support for user-defined BINDMOUNTs

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -332,7 +332,7 @@ cowbuilder_run() {
   echo "*** cowbuilder build phase for arch $architecture ***"
   mkdir -p "$WORKSPACE"/binaries/ /tmp/adt-$$ /tmp/apt-$$
 
-  local BINDMOUNTS="/tmp/adt-$$ /tmp/apt-$$ /var/cache/pbuilder/build"
+  local BINDMOUNTS="/tmp/adt-$$ /tmp/apt-$$ /var/cache/pbuilder/build ${USER_BINDMOUNTS:-}"
 
   # make sure we build arch specific packages only when necessary
   identify_build_type


### PR DESCRIPTION
There seems to be no obvious way to add user-defined BINDMOUNTS. Defining BINDMOUNTS in the user-defined pbuilderrc completely overrides the --bindmounts command line setting, wrecking any /tmp/apt-$$ and other bindmounts set in the script.

I've added a USER_BINDMOUNTS variable that provides a simple way to add your own bindmounts, and it works.
