### PR TITLE
Force local apt release repos to be trusted

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -354,8 +354,8 @@ cowbuilder_run() {
     if [ -d "$REPOSITORY" ]; then
       BINDMOUNTS="$BINDMOUNTS $REPOSITORY"
       cat > /tmp/apt-$$/release.list <<EOF
-deb file://${REPOSITORY} ${release} main
-deb-src file://${REPOSITORY} ${release} main
+deb [trusted=yes] file://${REPOSITORY} ${release} main
+deb-src [trusted=yes] file://${REPOSITORY} ${release} main
 EOF
     fi
   fi


### PR DESCRIPTION
Building a binary that depends on locally-created debs from a previous Jenkins build that are bind mounted into `/tmp/apt-$$` fails if they are untrusted. Since it is assumed that what we force into `/tmp/apt-$$`, say for a release build, is (almost by definition) trusted, I've added `[trusted=yes]` to the deb sources as described in https://wiki.debian.org/PbuilderTricks#How_to_include_local_packages_in_the_build.
