### PR TITLE
Create .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+# Michael Prokop's multiple personalities
+<mika@grml.org> <github@michael-prokop.at>
+<mika@grml.org> <mika@debian.org>
+<mika@grml.org> <mprokop@sipwise.com>
+<mika@grml.org> <prokop@grml-solutions.com>
+
+Sławomir Bocheński <lkslawek@gmail.com>
+Alexander Wirt <formorer@debian.org> <formorer@grml.org>


### PR DESCRIPTION
How about .mailmap? Ok, this is just pedantry, but `git shortlog` works much better this way. Sorry for arbitrary choices I made here for you and Alexander - those were based purely on statistics.
