### PR TITLE
piuparts_wrapper: scriptsdir cleanup

### DIFF
--- a/scripts/piuparts_wrapper
+++ b/scripts/piuparts_wrapper
@@ -28,8 +28,14 @@ if [ -n "${SCRIPTSDIR:-}" ] ; then
   echo "*** SCRIPTSDIR variable is set to $SCRIPTSDIR - using for piuparts run ***"
   scriptsdir="--scriptsdir=$SCRIPTSDIR"
 else
-  echo "*** SCRIPTSDIR variable is NOT set - using default [/etc/piuparts/scripts/] for piuparts run ***"
-  scriptsdir="--scriptsdir=/etc/piuparts/scripts/"
+  scriptsdir_path="/etc/piuparts/scripts/"
+  if [ -d "${scriptsdir_path}" ]; then
+    echo "*** SCRIPTSDIR variable is NOT set - using default [/etc/piuparts/scripts/] for piuparts run ***"
+    scriptsdir="--scriptsdir=${scriptsdir_path}"
+  else
+    # Some old piuparts do not ship a scripts dir
+    scriptsdir=""
+  fi
 fi
 
 create_base_tgz() {


### PR DESCRIPTION
scriptsdir was not quoted when passed to piuparts, that could cause an issue
when a user pass a path using a space.

on Ubuntu Precise, /etc/piuparts/scrips does not exist, the default always
assumed it existed, skip it when it does not.
