### PR TITLE
piuparts_wrapper: only expand scriptsdir when it is set

### DIFF
--- a/scripts/piuparts_wrapper
+++ b/scripts/piuparts_wrapper
@@ -26,12 +26,12 @@ fi
 
 if [ -n "${SCRIPTSDIR:-}" ] ; then
   echo "*** SCRIPTSDIR variable is set to $SCRIPTSDIR - using for piuparts run ***"
-  scriptsdir="--scriptsdir=$SCRIPTSDIR"
+  scriptsdir="$SCRIPTSDIR"
 else
   scriptsdir_path="/etc/piuparts/scripts/"
   if [ -d "${scriptsdir_path}" ]; then
     echo "*** SCRIPTSDIR variable is NOT set - using default [/etc/piuparts/scripts/] for piuparts run ***"
-    scriptsdir="--scriptsdir=${scriptsdir_path}"
+    scriptsdir="${scriptsdir_path}"
   else
     # Some old piuparts do not ship a scripts dir
     scriptsdir=""
@@ -114,6 +114,6 @@ piuparts \
   ${warn_on_leftovers_after_purge_option:-} \
   ${skip_logrotatefiles_test_option:-} \
   --log-file='piuparts.txt' \
-  "${scriptsdir:-}" \
+  ${scriptsdir:+--scriptsdir "$scriptsdir"} \
   ${basetgz:-} \
   "$@"


### PR DESCRIPTION
We started quoting $scriptsdir in 841b4b2 in case it is being passed a
string containing spaces.  That caused an issue whenever the scriptsdir
is empty: piuparts would be given an empty string as an argument which
does not play well.

This script makes $scriptdir to only contains the path, and expand it to
"--scriptsdir $scriptsdir" only if $scriptsdir exist.  That would let
the wrapper works properly whenever the scriptdir is empty by simply
discarding the option, but still quoting it properly when it is set.

Change-Id: I48c8e86ac007108ca6b650673087160a99d18a21
