### PR TITLE
The given $REPOS variable may also point to a suite, not only a codename...

### DIFF
--- a/scripts/generate-reprepro-codename
+++ b/scripts/generate-reprepro-codename
@@ -54,7 +54,7 @@ if [ -z "${KEY_ID:-}" ] ; then
   echo "***          and then adjust /etc/jenkins/debian_glue."
 fi
 
-if grep -q "^Codename: ${REPOS}$" "${REPOSITORY}"/conf/distributions ; then
+if grep -q "^\(Codename\|Suite\): ${REPOS}$" "${REPOSITORY}"/conf/distributions ; then
   echo "Codename/repository $REPOS exists already, ignoring request to add again."
   exit 0
 fi

--- a/scripts/remove-reprepro-codename
+++ b/scripts/remove-reprepro-codename
@@ -27,7 +27,7 @@ if ! [ -r "${REPOSITORY}/conf/distributions" ] ; then
   exit 1
 fi
 
-if ! grep -q "^Codename: ${codename}$" "${REPOSITORY}/conf/distributions" ; then
+if ! grep -q "^\(Codename\|Suite\): ${codename}$" "${REPOSITORY}/conf/distributions" ; then
   echo "*** Codename $codename does not exist in ${REPOSITORY}/conf/distributions - nothing to do."
   exit 0
 fi


### PR DESCRIPTION
Reprepro accepts suite names as aliases for codenames so we should do so too. Otherwise generate-reprepro-codename might add a new distribution for a repository that already exists but only as an alias via the suite parameter.
