### PR TITLE
Don't include sources, in sources.list. They're not needed for building.

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -355,7 +355,6 @@ cowbuilder_run() {
       BINDMOUNTS="$BINDMOUNTS $REPOSITORY"
       cat > /tmp/apt-$$/release.list <<EOF
 deb [trusted=yes] file://${REPOSITORY} ${release} main
-deb-src [trusted=yes] file://${REPOSITORY} ${release} main
 EOF
     fi
   fi


### PR DESCRIPTION
It doesn't really hurt to have to line in the sources list file but IMHO it's also not needed for building packages so it can be removed as well. It's also not guaranteed that there even is a source repository.
