### PR TITLE
Make it possible to verify our own reprepro repositories by providing a pubkey.

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -2,6 +2,9 @@
 # Install this file as /etc/jenkins/debian_glue to enable it.
 
 # Set GnuPG ID that should be used for signing the reprepro repository.
+# If you build packages for Squeeze your reprepro repositories *MUST* be
+# signed and the keyring that holds the public key (REPOSITORY_KEYRING)
+# must be set.
 # Expected format: DEADBEEF
 # KEY_ID=
 
@@ -30,6 +33,14 @@
 # Base directory for reprepro repositories
 # Default:
 # REPOSITORY='/srv/repository'
+
+# By default reprepro repositories are not verified but assumed to be
+# trustworthy.
+# Please note that if you build packages for Squeeze, the reprepro
+# repositories *MUST* be signed and verifiable. I.e. you need to set
+# KEY_ID and the corresponding keyring in REPOSITORY_KEYRING that
+# holds the public key portion for that KEY_ID.
+# REPOSITORY_KEYRING=/etc/apt/trusted.gpg.d/my-custom-keyring.gpg
 
 # If $release is set then "${REPOSITORY}/release/${release}"
 # is used as release repository. If you want to use a different

--- a/pbuilder-hookdir/D20releaserepo
+++ b/pbuilder-hookdir/D20releaserepo
@@ -5,10 +5,25 @@ set -ex
 set -- /tmp/apt-*/
 TMPAPT="$1"
 
-if [ -d "$TMPAPT" ] && ls ${TMPAPT}*.list 2>/dev/null; then
-  echo "Using additional apt sources:"
-  cat ${TMPAPT}*.list
+if [ -d "$TMPAPT" ]; then
+  UPDATE_PKGLIST=0
 
-  cp ${TMPAPT}*.list /etc/apt/sources.list.d/
-  /usr/bin/apt-get update
+  if ls "${TMPAPT}"*.list 2>/dev/null; then
+    echo "Using additional apt sources:"
+    cat "${TMPAPT}"*.list
+
+    cp "${TMPAPT}"*.list /etc/apt/sources.list.d/
+
+    UPDATE_PKGLIST=1
+  fi
+
+  if [ -e "${TMPAPT}/keyring.gpg" ]; then
+    echo "Using keyring for additional apt sources."
+
+    cp "${TMPAPT}/keyring.gpg" /etc/apt/trusted.gpg.d
+  fi
+
+  if [ "$UPDATE_PKGLIST" = 1 ]; then
+    /usr/bin/apt-get update
+  fi
 fi

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -355,9 +355,22 @@ cowbuilder_run() {
       BINDMOUNTS="$BINDMOUNTS $REPOSITORY"
       local components="$(awk -F': ' '/^Components:/ { print $2 }' \
         "${REPOSITORY}/dists/${release}/Release")"
+      # Check if keyring is provided so the repository can be verified.
+      if [ -n "${REPOSITORY_KEYRING:-}" ]; then
+        local trusted=
+      else
+        # If no keyring is provided, just assume that the repository is
+        # trustworthy. This option appeared in apt 0.8.16~exp3 which is not
+        # available in Squeeze.
+        local trusted="[trusted=yes]"
+      fi
       cat > /tmp/apt-$$/release.list <<EOF
-deb [trusted=yes] file://${REPOSITORY} ${release} ${components}
+deb ${trusted} file://${REPOSITORY} ${release} ${components}
 EOF
+    fi
+
+    if [ -n "${REPOSITORY_KEYRING:-}" ]; then
+      cp -a "${REPOSITORY_KEYRING}" /tmp/apt-$$/keyring.gpg
     fi
   fi
 


### PR DESCRIPTION
Verifying the integrity of our repository is basically mandatory when the build server is separated from the repository server. Additionally, if you want to build a package for Squeeze that has a dependency on a package from our repository the package list _MUST_ be verified because "[trusted=yes]" in the sources list is not yet supported by that apt version.
