### PR TITLE
Empty 'distribution' and 'architecture' env vars now do not break script...

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -239,14 +239,14 @@ cowbuilder_init() {
 
   if [ ! -d "${COWBUILDER_BASE}" ]; then
     echo "*** Creating cowbuilder base $COWBUILDER_BASE for arch $arch and distribution $COWBUILDER_DIST ***"
-    sudo DIST=${distribution} ARCH=${architecture} cowbuilder --create --basepath "${COWBUILDER_BASE}" --distribution "${COWBUILDER_DIST}" \
+    sudo DIST="${distribution:-}" ARCH="${architecture:-}" cowbuilder --create --basepath "${COWBUILDER_BASE}" --distribution "${COWBUILDER_DIST}" \
          --debootstrapopts --arch --debootstrapopts "$arch" \
          --debootstrapopts --variant=buildd --configfile="${pbuilderrc}" \
          --hookdir "${PBUILDER_HOOKDIR}"
     [ $? -eq 0 ] || bailout 1 "Error: Failed to create cowbuilder base ${COWBUILDER_BASE}."
   else
     echo "*** Updating cowbuilder cow base ***"
-    sudo DIST=${distribution} ARCH=${architecture} cowbuilder --update --basepath "${COWBUILDER_BASE}" --configfile="${pbuilderrc}"
+    sudo DIST="${distribution:-}" ARCH="${architecture:-}" cowbuilder --update --basepath "${COWBUILDER_BASE}" --configfile="${pbuilderrc}"
     [ $? -eq 0 ] || bailout 1 "Error: Failed to update cowbuilder base ${COWBUILDER_BASE}."
   fi
 


### PR DESCRIPTION
... when calling cowbuilder. The `build-and-provide-package` script is run with `set -u` in force, which causes an error if an env var is dereferenced but has never been set. The `distribution` and `architecture` env vars are set elsewhere, but are `local`, so not exported to the rest of the script and thus non-existent when dereferenced.

I have simply allowed these variables to be empty, since they are documented as being optional.

Note that sudoers may need to allow DIST and ARCH environment variables to be passed, e.g.

`Defaults  env_keep+="DIST ARCH"`
