### PR TITLE
Fix repository overwrite

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -32,7 +32,7 @@
 
 # Base directory for reprepro repositories
 # Default:
-# REPOSITORY='/srv/repository'
+DEFAULT_REPOSITORY='/srv/repository'
 
 # By default reprepro repositories are not verified but assumed to be
 # trustworthy.

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -36,7 +36,7 @@ checks_and_defaults() {
   fi
 
   if [ -z "${REPOSITORY:-}" ] ; then
-    REPOSITORY='/srv/repository'
+    REPOSITORY=${DEFAULT_REPOSITORY}
   fi
 
   if [ -z "${PBUILDER_HOOKDIR:-}" ] ; then

--- a/scripts/generate-reprepro-codename
+++ b/scripts/generate-reprepro-codename
@@ -58,12 +58,12 @@ if [ -n "${JENKINS_DEBIAN_GLUE_VERSION:-}" ] ; then
 fi
 
 if [ -z "${REPOSITORY:-}" ] ; then
-  REPOSITORY='/srv/repository'
+  REPOSITORY=${DEFAULT_REPOSITORY}
   echo "*** Repository variable REPOSITORY is unset, using default [$REPOSITORY] ***"
 fi
 
 if ! ${SUDO_CMD:-} mkdir -p "${REPOSITORY}"/conf ; then
-  echo "Error creating ${REPOSITORY}/conf (forgot to create /srv/repository and chown jenkins?)" >&2
+  echo "Error creating ${REPOSITORY}/conf (forgot to create ${DEFAULT_REPOSITORY} and chown jenkins?)" >&2
   exit 1
 fi
 

--- a/scripts/remove-reprepro-codename
+++ b/scripts/remove-reprepro-codename
@@ -8,7 +8,7 @@ if [ -r /etc/jenkins/debian_glue ] ; then
 fi
 
 if [ -z "${REPOSITORY:-}" ] ; then
-  REPOSITORY='/srv/repository'
+  REPOSITORY=${DEFAULT_REPOSITORY}
 fi
 
 if [ -z "${REPREPRO_OPTS:-}" ]  ; then

--- a/scripts/repository_checker
+++ b/scripts/repository_checker
@@ -8,7 +8,7 @@ if [ -r /etc/jenkins/debian_glue ] ; then
 fi
 
 if [ -z "${REPOSITORY:-}" ] ; then
-  REPOSITORY='/srv/repository'
+  REPOSITORY=${DEFAULT_REPOSITORY}
 fi
 
 if [ -z "${REPREPRO_OPTS:-}" ]  ; then


### PR DESCRIPTION
Including `/etc/jenkins/debian_glue` in `generate-reprepro-codename` overwrite previously defined `REPOSITORY` variable value.

When using a custom `REPOSITORY` value in `/etc/jenkins/debian_glue`, release packages will be pushed in the wrong repository because scripts also use `REPOSITORY` variable.

This fix renames `REPOSITORY` into `DEFAULT_REPOSITORY` in `/etc/jenkins/debian_glue` and use it instead of hardcoded `/srv/repository` as default value in all scripts.