### PR TITLE
tap_tool_dispatcher: run all tools in parallel

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -89,6 +89,7 @@ Package: jenkins-debian-glue-buildenv-taptools
 Architecture: all
 Depends: devscripts,
          libperl-critic-perl,
+         parallel,
          ruby,
          ${misc:Depends}
 Recommends: devscripts,

--- a/tap/tap_tool_dispatcher
+++ b/tap/tap_tool_dispatcher
@@ -18,24 +18,13 @@ fi
 
 # start with clean report dir
 rm -rf "${REPORTS_DIRECTORY}"
-mkdir -p "${REPORTS_DIRECTORY}"/perl
-mkdir -p "${REPORTS_DIRECTORY}"/shell
-mkdir -p "${REPORTS_DIRECTORY}"/python
 
-# run perlcritic_tap
-echo "*** perlcritic_tap ***"
-find source -type f ! -path '*.svn*' ! -path '*.git/*' -prune -exec \
-  sh -c 'input="$1"; output=$(echo $input | sed -e s,/,_,g); /usr/bin/perlcritic_tap "$input" > "${REPORTS_DIRECTORY}/perl/${output}".tap' '{}' '{}' ';'
-
-# run checkbashism_tap
-echo "*** checkbashism_tap ***"
-find source -type f ! -path '*.svn*' ! -path '*.git/*' -prune -exec \
-  sh -c 'input="$1"; output=$(echo $input | sed -e s,/,_,g); /usr/bin/checkbashism_tap "$input" > "${REPORTS_DIRECTORY}/shell/${output}".tap' '{}' '{}' ';'
-
-# run pep8_tap
-echo "*** pep8_tap ***"
-find source -type f ! -path '*.svn*' ! -path '*.git/*' -prune -exec \
-  sh -c 'file "$1" | grep -q "Python script" && input="$1" && output=$(echo $input | sed -e s,/,_,g) && /usr/bin/pep8_tap "$input" > "${REPORTS_DIRECTORY}/python/${output}".tap' '{}' '{}' ';'
+# run all tap tools at once, in parallel
+find source -type f ! -path '*.svn*' ! -path '*.git/*' ! -name '.gitignore' -prune | parallel -v -- \
+  mkdir -p ${REPORTS_DIRECTORY}'/'{//} ';' \
+  /usr/bin/checkbashism_tap '{}' '>' ${REPORTS_DIRECTORY}'/{}_checkbashism.tap' ';' \
+  /usr/bin/perlcritic_tap '{}' '>' ${REPORTS_DIRECTORY}'/{}_perlcritic.tap' ';' \
+  /usr/bin/pep8_tap '{}' '>' ${REPORTS_DIRECTORY}'/{}_pep8.tap' ';'
 
 # get rid of empty files
 find "${REPORTS_DIRECTORY}" -type f -empty -exec rm {} +


### PR DESCRIPTION
Running the different *_tap tools in parallel allows for significant
speedups on our build server; a job with ~440 files took 1min35s
previously, and now takes < 30s to complete.
