### PR TITLE
pep8_tap: don't reenable default-disabled checkers

### DIFF
--- a/tap/pep8_no_disabled_issues
+++ b/tap/pep8_no_disabled_issues
@@ -36,7 +36,7 @@ end
 
 ISSUE_PREFIX = 'ISSUE:'
 
-output = %x{pep8 -r --show-source --select E,W --format 'ISSUE:%(path)s:%(row)d:%(col)d: %(code)s %(text)s' #{file} 2>&1}
+output = %x{pep8 -r --show-source --format 'ISSUE:%(path)s:%(row)d:%(col)d: %(code)s %(text)s' #{file} 2>&1}
 
 def is_issue_line(l)
   l.start_with?(ISSUE_PREFIX)


### PR DESCRIPTION
As explained in https://github.com/jcrocholl/pep8/issues/212, some checkers are disabled by default, as they only apply to old PEP8 versions. We shouldn't turn them on again.
