### PR TITLE
Always call svn upgrade... 

### DIFF
--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -61,6 +61,10 @@ if ! [ -r debian/changelog ] ; then
   exit 1
 fi
 
+# Force the upgrade. Otherwise, if the system has been upgraded, the 'svn info'
+# will fail with an unhelpful error message
+svn upgrade 2>/dev/null
+
 SINCE_REVISION=$(svn info debian/changelog 2>/dev/null | awk '/Last Changed Rev:/ {print $4}')
 
 if [ -z "${SINCE_REVISION:-}" ] ; then


### PR DESCRIPTION
Under Ubuntu precise, recently upgraded, the svn version changed causing this error in jenkins-debian-glue
```
++ svn info debian/changelog
++ awk '/Last Changed Rev:/ {print $4}'
+ SINCE_REVISION=
+ '[' -z '' ']'
+ echo 'Error: could not detect svn revision which modified debian/changelog.'
Error: could not detect svn revision which modified debian/changelog.
```

As you can see, that is not obvious.
Calling the command by hand makes it much more obvious:
```
svn: E155036: Please see the 'svn upgrade' command
svn: E155036: The working copy at '/home/jenkins/jobs/llvm-toolchain-precise-3.6-source/workspace/source/debian'
is too old (format 8) to work with client version '1.8.10 (r1615264)' (expects format 31). You need to upgrade the working copy first.
```