### PR TITLE
Cowbuilder mirror and keyring selection

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -231,17 +231,6 @@ cowbuilder_init() {
     echo "COMPONENTS=\"${COMPONENTS}\"" >> "$pbuilderrc"
   fi
 
-  # workaround for Ubuntu problem, as cowdancer is available only in universe :(
-  # https://bugs.launchpad.net/ubuntu/+source/cowdancer/+bug/237591
-  # https://bugs.launchpad.net/ubuntu/+source/cowdancer/+bug/747053
-  if lsb_release --id 2>/dev/null | grep -q Ubuntu ; then
-    if [ -z "${COMPONENTS:-}" ] ; then
-      echo "*** Ubuntu detected, enabling universe repository component to work around cowdancer issue ***"
-      echo "# Ubuntu detected, enabling universe repository component to work around cowdancer issue:" >> "$pbuilderrc"
-      echo 'COMPONENTS="main universe"' >> "$pbuilderrc"
-    fi
-  fi
-
   echo "*** Listing pbuilder configuration file as reference: ***"
   cat "$pbuilderrc"
 
@@ -709,6 +698,7 @@ EOF
 }
 
 deploy_to_releases() {
+  sed -i "s/Distribution: .*/Distribution: ${distribution}/" "${WORKSPACE}/binaries/"*"${newest_version}"_${architecture}.changes
   if [ -n "${USE_FREIGHT:-}" ] ; then
     freight_wrapper
     # Freight is currently not able to manage release or trunk release repos,

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -187,7 +187,7 @@ dist_and_arch_settings() {
     # default to the currently running distribution to avoid hardcoding
     # a distribution which might not be supported by the running system
     local distribution=$(lsb_release --short --codename 2>/dev/null)
-    [ -n "${distribution}" ] || distribution="sid"  # fallback to "sid" iff lsb_release fails
+    [ -n "${distribution}" ] || distribution="sid"  # fallback to "sid" if lsb_release fails
     local DIST="$distribution"
   fi
 
@@ -577,9 +577,6 @@ reprepro_wrapper() {
 
 dput_wrapper() {
   command -v dput || bailout 1 "Error: dput not found."
-
-  remove_packages
-  remove_missing_binary_packages
 
   archall=false
   case $architecture in


### PR DESCRIPTION
Added cowbuilder mirror and keyring selection based on suite name. Without it I could not build debian base on ubuntu, maybe there is another way. Tested on trusty host to build wheezy/sid bases.

Needs debian-archive-keyring on ubuntu and ubuntu-archive-keyring on debian.