### PR TITLE
generate-git-snapshot: replace distribution dashes in version

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -85,7 +85,7 @@ version_information() {
 
   if [ -n "${distribution:-}" ] ; then
     echo "Distribution variable found. Adding distribution specific version."
-    VERSION_STRING="${VERSION_STRING}+${distribution}"
+    VERSION_STRING="${VERSION_STRING}+${distribution//-/_}"
   fi
 
   echo "*** Version string set to $VERSION_STRING ***"


### PR DESCRIPTION
Wikimedia uses more specific distributions reusing the upstream name and
suffixed with '-wikimedia'.  Whenever $distribution is set, it is
injected in the version string by version_information().

When generating the original tarball, git buildpackage is given a
version such as:

 NoEpochVer: 2.0.0-wikimedia1+0~20150413152850+jessie-wikimedia~1.gbpe39408

From Debian Policy `5.6.12 Version`:

    "package management system will break the version number apart at
    the last hyphen in the string to determine the upstream_version and
    debian_revision"

git buildpackage yields:

 Uptream version: 2.0.0-wikimedia1+0~20150413152850+jessie
 Debian revision: wikimedia~1.gbpe39408

Instead of an upstream version of '2.0.0'.

When concatenating the version and distribution, replace any dashes in
$distribution by underscores.

 NoEpochVer: 2.0.0-wikimedia1+0~20150413152850+jessie_wikimedia~1.gbpe39408
 Upstream version: 2.0.0
 Debian revision: wikimedia1+0~20150413152850+jessie_wikimedia~1.gbpe39408