### PR TITLE
add options to deal with validate and packages with version != source

### DIFF
--- a/scripts/repository_checker
+++ b/scripts/repository_checker
@@ -46,6 +46,7 @@ Validation options:
 
   --validate-source-bin-versions    Make sure source packages match with binary package versions.
   --validate-incoming               Make sure there are no leftover files in incoming repositories.
+  --version-remove-epoch            Remove epoch from package version
 
 Misc options:
 
@@ -82,6 +83,14 @@ validate-incoming() {
   return $rc
 }
 
+_remove_epoch() {
+  if [[ "$1" =~ ^[[:digit:]]+:(.*) ]] ; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "$1"
+  fi
+}
+
 validate-source-bin-versions() {
   rc=0
 
@@ -90,6 +99,11 @@ validate-source-bin-versions() {
       sourceversion=$(reprepro $REPREPRO_OPTS -A source -b "${REPOSITORY}" --list-format='${version}\n' list $repository $sourcepackage 2>"${LOGFILE}")
       for binarypackage in $(reprepro $REPREPRO_OPTS -b "${REPOSITORY}" --list-format='${package}\n' -T deb listfilter "$repository" "\$Source (==$sourcepackage)" 2>"${LOGFILE}") ; do
         archversion=$(reprepro $REPREPRO_OPTS -A amd64 -b "${REPOSITORY}" --list-format='${version}\n' list $repository $binarypackage 2>"${LOGFILE}")
+
+        if $_opt_version_remove_epoch ; then
+          sourceversion=$(_remove_epoch $sourceversion)
+          archversion=$(_remove_epoch $archversion)
+        fi
 
         if [ -z "$archversion" ] && [ -n "$sourceversion" ] ; then
           echo "Warning: package $binarypackage in repository $repository has sourceversion $sourceversion but lacks archversion"
@@ -120,7 +134,7 @@ validate-source-bin-versions() {
 trap bailout SIGHUP SIGINT SIGQUIT SIGABRT SIGKILL SIGALRM SIGTERM
 
 # command line handling
-CMDLINE_OPTS=list-package:,list-binary-package:,list-binary-repos:,list-repos:,list-source-package:,list-source-repos:,repository:,,help,validate-incoming,validate-source-bin-versions,version
+CMDLINE_OPTS=list-package:,list-binary-package:,list-binary-repos:,list-repos:,list-source-package:,list-source-repos:,repository:,,help,validate-incoming,validate-source-bin-versions,version,version-remove-epoch
 
 _opt_temp=$(getopt --name repository_checker -o +vhV --long $CMDLINE_OPTS -- "$@")
 if [ $? -ne 0 ]; then
@@ -138,6 +152,7 @@ _opt_list_source_package=false
 _opt_list_source_repos=false
 _opt_validate_source_bin_versions=false
 _opt_validate_incoming=false
+_opt_version_remove_epoch=false
 
 while :; do
   case "$1" in
@@ -173,6 +188,9 @@ while :; do
     ;;
   --version)
     echo "$0 version $JENKINS_DEBIAN_GLUE_VERSION"; exit 0;
+    ;;
+  --version-remove-epoch)
+    _opt_version_remove_epoch=true
     ;;
   --)
     shift; break

--- a/scripts/repository_checker
+++ b/scripts/repository_checker
@@ -44,9 +44,10 @@ Configuration options:
 
 Validation options:
 
-  --validate-source-bin-versions    Make sure source packages match with binary package versions.
-  --validate-incoming               Make sure there are no leftover files in incoming repositories.
-  --version-remove-epoch            Remove epoch from package version
+  --validate-source-bin-versions     Make sure source packages match with binary package versions.
+  --validate-incoming                Make sure there are no leftover files in incoming repositories.
+  --validate-skip-package <packages> List of source packages to skip.
+  --version-remove-epoch             Remove epoch from package version
 
 Misc options:
 
@@ -91,13 +92,31 @@ _remove_epoch() {
   fi
 }
 
+_skip_package() {
+  local p
+  for p in $1; do
+    [[ $p = $2 ]] && return 0
+  done
+  return 1
+}
+
 validate-source-bin-versions() {
   rc=0
 
   for repository in $(awk '/^Codename: / {print $2}' "${REPOSITORY}"/conf/distributions 2>"${LOGFILE}") ; do
     for sourcepackage in $(reprepro $REPREPRO_OPTS -A source -b "${REPOSITORY}" --list-format='${package}\n' list $repository 2>"${LOGFILE}") ; do
+      if _opt_validate_skip_package && _skip_package "${SKIP_PACKAGE}" "$sourcepackage" ; then
+        echo "skipping: $sourcepackage"
+        continue
+      fi
       sourceversion=$(reprepro $REPREPRO_OPTS -A source -b "${REPOSITORY}" --list-format='${version}\n' list $repository $sourcepackage 2>"${LOGFILE}")
       for binarypackage in $(reprepro $REPREPRO_OPTS -b "${REPOSITORY}" --list-format='${package}\n' -T deb listfilter "$repository" "\$Source (==$sourcepackage)" 2>"${LOGFILE}") ; do
+
+        if _opt_validate_skip_package && _skip_package "${SKIP_PACKAGE}" "$binarypackage" ; then
+          echo "skipping: $binarypackage"
+          continue
+        fi
+
         archversion=$(reprepro $REPREPRO_OPTS -A amd64 -b "${REPOSITORY}" --list-format='${version}\n' list $repository $binarypackage 2>"${LOGFILE}")
 
         if $_opt_version_remove_epoch ; then
@@ -134,7 +153,7 @@ validate-source-bin-versions() {
 trap bailout SIGHUP SIGINT SIGQUIT SIGABRT SIGKILL SIGALRM SIGTERM
 
 # command line handling
-CMDLINE_OPTS=list-package:,list-binary-package:,list-binary-repos:,list-repos:,list-source-package:,list-source-repos:,repository:,,help,validate-incoming,validate-source-bin-versions,version,version-remove-epoch
+CMDLINE_OPTS=list-package:,list-binary-package:,list-binary-repos:,list-repos:,list-source-package:,list-source-repos:,repository:,,help,validate-incoming,validate-source-bin-versions,version,version-remove-epoch,validate-skip-package:
 
 _opt_temp=$(getopt --name repository_checker -o +vhV --long $CMDLINE_OPTS -- "$@")
 if [ $? -ne 0 ]; then
@@ -153,6 +172,7 @@ _opt_list_source_repos=false
 _opt_validate_source_bin_versions=false
 _opt_validate_incoming=false
 _opt_version_remove_epoch=false
+_opt_validate_skip_package=false
 
 while :; do
   case "$1" in
@@ -191,6 +211,9 @@ while :; do
     ;;
   --version-remove-epoch)
     _opt_version_remove_epoch=true
+    ;;
+  --validate-skip-package)
+    shift; _opt_validate_skip_package=true ; SKIP_PACKAGE="$1"
     ;;
   --)
     shift; break


### PR DESCRIPTION
Some packages have:
iproute: arch version [1:3.16.0-2~bpo70+1] vs. sourceversion [3.16.0-2~bpo70+1]
iproute-doc: arch version [1:3.16.0-2~bpo70+1] vs. sourceversion [3.16.0-2~bpo70+1]

Or even:
linux-headers-amd64: arch version [3.16+62~bpo70+1] vs. sourceversion [62~bpo70+1]
linux-image-amd64: arch version [3.16+62~bpo70+1] vs. sourceversion [62~bpo70+1]