### PR TITLE
Add support for devuan, ccache, eatmydata, git format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ install: $(scripts)
 
 	mkdir -p $(DESTDIR)/usr/share/jenkins-debian-glue/examples/
 	install -m 0664 examples/* $(DESTDIR)/usr/share/jenkins-debian-glue/examples/
+	mkdir -p $(DESTDIR)/usr/share/jenkins-debian-glue/examples/devuan
+	install -m 0664 devuan/* $(DESTDIR)/usr/share/jenkins-debian-glue/examples/devuan/
 	mkdir -p $(DESTDIR)/usr/share/jenkins-debian-glue/pbuilder-hookdir/
 	install -m 0775 pbuilder-hookdir/* $(DESTDIR)/usr/share/jenkins-debian-glue/pbuilder-hookdir/
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 jenkins-debian-glue
 ===================
 
-Continuous Integration for Debian and Ubuntu made easy.
-jenkins-debian-glue allows you to build Debian and Ubuntu packages
+Continuous Integration for Debian, Ubuntu and Devuan made easy.
+jenkins-debian-glue allows you to build Debian, Ubuntu and Devuan packages
 directly from the Jenkins Continuous Integration system.
 
 Please head over to [jenkins-debian-glue.org](http://jenkins-debian-glue.org/)

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,8 @@ Depends: cowbuilder,
          devscripts,
          dpkg-dev,
          jenkins-debian-glue,
-         quilt
+         quilt,
+         ccache, eatmydata
 Description: Virtual package to be used on build slaves
  This virtual package depends on the software packages required
  for using jenkins-debian-glue as build environment.
@@ -117,3 +118,14 @@ Description: piuparts integration in Jenkins
  package installation and upgrades of generated Debian packages.
  The scripts can be used for generating TAP reports of piuparts
  runs checking Debian packages inside Jenkins jobs.
+
+Package: jenkins-debian-glue-buildenv-devuan
+Architecture: all
+Depends: sudo,
+         jenkins-debian-glue-buildenv,
+         ${misc:Depends}
+Description: Devuan GNU/Linux support in jenkins debian glue
+ This package provides Devuan specific additional files
+ used for building Devuan packages.
+
+

--- a/debian/jenkins-debian-glue-buildenv-devuan.install
+++ b/debian/jenkins-debian-glue-buildenv-devuan.install
@@ -1,0 +1,2 @@
+debian/tmp/usr/share/jenkins-debian-glue/examples/devuan/pbuilderrc etc/jenkins/
+debian/tmp/usr/share/jenkins-debian-glue/examples/devuan/jenkins etc/sudoers.d/

--- a/devuan/jenkins
+++ b/devuan/jenkins
@@ -1,0 +1,2 @@
+jenkins ALL=NOPASSWD: /usr/sbin/cowbuilder, /usr/sbin/chroot, /bin/chmod, /bin/rm, /bin/mv, /bin/cat
+Defaults env_keep+="DEB_* DIST ARCH ADT QEMU_LOG_FILENAME"

--- a/devuan/pbuilderrc
+++ b/devuan/pbuilderrc
@@ -1,0 +1,5 @@
+MIRRORSITE="http://packages.devuan.org/merged/"
+COMPONENTS="main contrib non-free"
+DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/devuan-keyring.gpg")
+EXTRAPACKAGES="devuan-keyring"
+

--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -87,3 +87,17 @@
 # ADT_RUNNER="adt-virt-qemu /srv/adt-${distribution:-}-${architecture:-}.img"
 # Default:
 # ADT=
+
+
+# Use eatmydata (https://launchpad.net/libeatmydata) to disable
+# fsync(), O_SYNC and so on to speed up build.
+# Default:
+# USE_EATMYDATA=false
+
+# Use ccache to speed up builds on packages that 
+# needs to rebuild the same source multiple times by
+# caching build results
+# Default: 
+# USE_CCACHE=false
+
+

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -63,6 +63,14 @@ checks_and_defaults() {
     export DEB_KEEP_BUILD_ENV
   fi
 
+  if [ "${USE_EATMYDATA:-}" = true ] ; then
+    export USE_EATMYDATA
+  fi
+
+  if [ "${USE_CCACHE:-}" = true ] ; then
+    export USE_CCACHE
+  fi
+
   if [ -z "${JOB_NAME:-}" ] ; then
     echo "Error: No JOB_NAME defined, please run it in jenkins." >&2
     exit 1
@@ -256,6 +264,22 @@ cowbuilder_init() {
   # allow pbuilder networking
   if [ -n "${PBUILDER_USENETWORK:-}" ] ; then
     echo "USENETWORK=yes" >> "$pbuilderrc"
+  fi
+
+  # add libeatmydata to pbuilderrc
+  if [ "${USE_EATMYDATA:-}" = true ] ; then
+     echo 'EXTRAPACKAGES="$EXTRAPACKAGES eatmydata"' >> "$pbuilderrc"
+     echo 'if [ -z "$LD_PRELOAD" ]; then' >> "$pbuilderrc"
+     echo '   LD_PRELOAD=libeatmydata.so' >> "$pbuilderrc"
+     echo 'else' >> "$pbuilderrc"
+     echo '   LD_PRELOAD="$LD_PRELOAD":libeatmydata.so' >> "$pbuilderrc"
+     echo 'fi' >> "$pbuilderrc"
+     echo 'export LD_PRELOAD' >> "$pbuilderrc"
+  fi
+
+  # add ccache to pbuilderrc
+  if [ "${USE_CCACHE:-}" = true ] ; then
+     echo 'export CCACHEDIR="/var/cache/pbuilder/ccache"' >> "$pbuilderrc"
   fi
 
   # allow setting main pbuilder configuration file from outside, then append data
@@ -539,6 +563,23 @@ EOF
   if [ -n "${PBUILDER_USENETWORK:-}" ] ; then
     echo "USENETWORK=yes" >> "$pbuilderrc"
   fi
+
+  # add libeatmydata to pbuilderrc
+  if [ "${USE_EATMYDATA:-}" = true ] ; then
+     echo 'EXTRAPACKAGES="$EXTRAPACKAGES eatmydata"' >> "$pbuilderrc"
+     echo 'if [ -z "$LD_PRELOAD" ]; then' >> "$pbuilderrc"
+     echo '   LD_PRELOAD=libeatmydata.so' >> "$pbuilderrc"
+     echo 'else' >> "$pbuilderrc"
+     echo '   LD_PRELOAD="$LD_PRELOAD":libeatmydata.so' >> "$pbuilderrc"
+     echo 'fi' >> "$pbuilderrc"
+     echo 'export LD_PRELOAD' >> "$pbuilderrc"
+  fi
+
+  # add ccache to pbuilderrc
+  if [ "${USE_CCACHE:-}" = true ] ; then
+     echo 'export CCACHEDIR="/var/cache/pbuilder/ccache"' >> "$pbuilderrc"
+  fi
+
 
   # allow setting main pbuilder configuration file from outside, then append data
   # as needed without actually writing anything to user-provided $PBUILDER_CONFIG

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -19,6 +19,7 @@ if [ ! -d "${SOURCE_DIRECTORY}" ] ; then
   exit 1
 fi
 
+
 if [ -z "${BUILD_NUMBER:-}" ] ; then
   echo "No BUILD_NUMBER defined, please run it in jenkins." >&2
   exit 1
@@ -344,6 +345,37 @@ quilt_cleanup() {
   rm -rf .pc
 }
 
+git_source_options() {
+	#Unless otherwise specified in the debian/source/options
+	# restrict git source archive depth and limit to only the branch we build.
+	if [ -z "${GIT_DEPTH:-}" ]; then
+		GIT_DEPTH=20
+	fi
+	local file
+	local value 
+	local opt_depth
+	local opt_ref
+	file="debian/source/options"
+	if [ -f ${file} ]; then
+		opt_depth=$(git config --file ${file} --get git-depth 2>&- || true)
+		opt_ref=$(git config --file ${file} --get git-ref 2>&- || true)
+	fi
+	if [ -z "${opt_depth:-}" ]; then
+		echo "Setting git source depth to $GIT_DEPTH"
+		DBP_EXTRA_OPTS="${DBP_EXTRA_OPTS:-} --source-option=--git-depth=$GIT_DEPTH"
+	else
+		echo "Using source depth of $opt_depth as defined in debian/source/options"
+	fi
+	if ![ -z "${opt_ref:-}" ]; then
+		echo "Setting git source ref to $GIT_REF"
+		DBP_EXTRA_OPTS="${DBP_EXTRA_OPTS:-} --source-option=--git-ref=${BRANCH}"
+	else
+		echo "Settin git source ref to $opt_ref as defined in debian/source/options"	
+	fi
+
+}
+
+
 source_format_opts() {
   if ! [ -f "debian/source/format" ] ; then
     echo '*** WARNING: Source format is not specified in debian/source/format! ***'
@@ -359,6 +391,7 @@ source_format_opts() {
       ;;
     '3.0 (git)')
       echo "*** Source format detected as 3.0 (git) ***"
+      git_source_options
       PRISTINE_TAR=false
       SKIP_QUILT_CLEANUP=true
       IGNORE_GIT_BUILDPACKAGE=true


### PR DESCRIPTION
As we in devuan build packages intensively, performances are great, so, with this pull request we add:

 * support for building with CCACHE ( false by default, usable concurrently with eatmydata )
 * support for building with EATMYDATA (false by default, usable concurrently with ccache)

Also, we add a jenkins-debian-glue-buildenv-devuan optional package that install some files specific for devuan packages

Last but not least, we introduce a way to limit the size of the git clone for git format packages, this is very usefull for packages with a huge commit history.

Enjoy!