### PR TITLE
Add option to keep version to what is defined in the control file

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -34,6 +34,13 @@
 # Default:
 # REPOSITORY='/srv/repository'
 
+# In order to keep the build versions unique and to ensure that there
+# are no duplicates, the version number from the changelog is padded
+# with the date and the build number.
+# To override this behaviour and preserve the version number from the
+# changelog, set this version to true
+# USE_ORIG_VERSION=true
+
 # By default reprepro repositories are not verified but assumed to be
 # trustworthy.
 # Please note that if you build packages for Squeeze, the reprepro

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -64,6 +64,7 @@ version_information() {
   # retrieve and adjust information
   ORIG_VERSION=$(dpkg-parsechangelog --count 1 | awk '/^Version/ {print $2}')
   DISTRIBUTION=$(dpkg-parsechangelog --count 1 | awk '/^Distribution/ {print $2}')
+  APPLY_VERSION_WORKAROUND=false
 
   if [ "$USE_ORIG_VERSION" = "true" ] ; then
     echo "USE_ORIG_VERSION is set to 'true', keeping original version from changelog"
@@ -78,7 +79,6 @@ version_information() {
 
     # we do NOT raise the version number, if we detect an unreleased version,
     # otherwise the released version would be older than our snapshot builds
-    APPLY_VERSION_WORKAROUND=false
     if [ "$DISTRIBUTION" = "UNRELEASED" ] && dpkg --compare-versions "$ORIG_VERSION" lt "$INCREASED_VERSION" ; then
       echo "*** Not increasing version number as distribution is set to UNRELEASED ***"
       INCREASED_VERSION="$ORIG_VERSION"

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -63,25 +63,29 @@ version_information() {
 
   # retrieve and adjust information
   ORIG_VERSION=$(dpkg-parsechangelog --count 1 | awk '/^Version/ {print $2}')
-  INCREASED_VERSION=$(increase-version-number $ORIG_VERSION)
   DISTRIBUTION=$(dpkg-parsechangelog --count 1 | awk '/^Distribution/ {print $2}')
 
-  # we want to get a version string like
-  # $ORIG_VERSION+0~$TIMESTAMP.$BUILD_NUMBER~1.$GIT_ID
-  # so the version is always increasing over time, no matter what
-  TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
-  BUILD_VERSION="${TIMESTAMP}.${BUILD_NUMBER}" # git-dch appends something like ~1.gbp5f433e then
+  if [ "$USE_ORIG_VERSION" = "true" ] ; then
+    echo "USE_ORIG_VERSION is set to 'true', keeping original version from changelog"
+    VERSION_STRING="${ORIG_VERSION}"
+  else
+    # we want to get a version string like
+    # $ORIG_VERSION+0~$TIMESTAMP.$BUILD_NUMBER~1.$GIT_ID
+    # so the version is always increasing over time, no matter what
+    INCREASED_VERSION=$(increase-version-number $ORIG_VERSION)
+    TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+    BUILD_VERSION="${TIMESTAMP}.${BUILD_NUMBER}" # git-dch appends something like ~1.gbp5f433e then
 
-  # we do NOT raise the version number, if we detect an unreleased version,
-  # otherwise the released version would be older than our snapshot builds
-  APPLY_VERSION_WORKAROUND=false
-  if [ "$DISTRIBUTION" = "UNRELEASED" ] && dpkg --compare-versions "$ORIG_VERSION" lt "$INCREASED_VERSION" ; then
-    echo "*** Not increasing version number as distribution is set to UNRELEASED ***"
-    INCREASED_VERSION="$ORIG_VERSION"
-    APPLY_VERSION_WORKAROUND=true
+    # we do NOT raise the version number, if we detect an unreleased version,
+    # otherwise the released version would be older than our snapshot builds
+    APPLY_VERSION_WORKAROUND=false
+    if [ "$DISTRIBUTION" = "UNRELEASED" ] && dpkg --compare-versions "$ORIG_VERSION" lt "$INCREASED_VERSION" ; then
+      echo "*** Not increasing version number as distribution is set to UNRELEASED ***"
+      INCREASED_VERSION="$ORIG_VERSION"
+      APPLY_VERSION_WORKAROUND=true
+    fi
+    VERSION_STRING="${INCREASED_VERSION}~${BUILD_VERSION}"
   fi
-
-  VERSION_STRING="${INCREASED_VERSION}~${BUILD_VERSION}"
 
   if [ -n "${distribution:-}" ] ; then
     echo "Distribution variable found. Adding distribution specific version."


### PR DESCRIPTION
By default, jenkins-debian-glue adds a +0, date and timestamp to the version number.
Adding the option to USE_ORIG_VERSION makes it possible for the package builder to control the versioning by editing the changelog if he so chooses.