### PR TITLE
Support muting command printing in shell scripts

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [ -z ${JENKINS_DEBIAN_GLUE_QUIET:-} ]; then
+  set -x
+fi
 set -u
 
 # make sure cowbuilder/pbuilder/... are available

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [ -z ${JENKINS_DEBIAN_GLUE_QUIET:-} ]; then
+  set -x
+fi
 set -e
 set -u
 

--- a/scripts/generate-reprepro-codename
+++ b/scripts/generate-reprepro-codename
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [ -z ${JENKINS_DEBIAN_GLUE_QUIET:-} ]; then
+  set -x
+fi
 set -e
 
 bailout() {

--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [ -z ${JENKINS_DEBIAN_GLUE_QUIET:-} ]; then
+  set -x
+fi
 set -e
 set -u
 

--- a/scripts/remove-reprepro-codename
+++ b/scripts/remove-reprepro-codename
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -x
+if [ -z ${JENKINS_DEBIAN_GLUE_QUIET:-} ]; then
+  set -x
+fi
 set -e
 
 if [ -r /etc/jenkins/debian_glue ] ; then


### PR DESCRIPTION
Introduce the env variable JENKINS_DEBIAN_GLUE_QUIET to turn off the
bash option 'set -x' in various scripts.

To mute them, simply set the variable to any value.