### PR TITLE
Remove ARCH variable from cowbuilder command

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -381,7 +381,7 @@ cowbuilder_init() {
 
   if [ ! -d "${COWBUILDER_BASE}" ]; then
     echo "*** Creating cowbuilder base $COWBUILDER_BASE for arch $arch and distribution $COWBUILDER_DIST ***"
-    sudo DIST="${distribution:-}" ARCH="${architecture:-}" ${ADT:+ADT=$ADT} \
+    sudo ${ADT:+ADT=$ADT} \
       cowbuilder --create --basepath "${COWBUILDER_BASE}" --distribution "${COWBUILDER_DIST}" \
          --debootstrap "${DEBOOTSTRAP}" --architecture "${architecture:-}" \
          --debootstrapopts --arch --debootstrapopts "$arch" \
@@ -390,8 +390,9 @@ cowbuilder_init() {
     [ $? -eq 0 ] || exit 2
   else
     echo "*** Updating cowbuilder cow base ***"
-    sudo DIST="${distribution:-}" ARCH="${architecture:-}" ${ADT:+ADT=$ADT} \
-      cowbuilder --update --basepath "${COWBUILDER_BASE}" --configfile="${pbuilderrc}"
+    sudo ${ADT:+ADT=$ADT} \
+      cowbuilder --update --basepath "${COWBUILDER_BASE}" --configfile="${pbuilderrc}" \
+         --distribution "${COWBUILDER_DIST}" --architecture "${architecture:-}"
     [ $? -eq 0 ] || exit 3
   fi
   ) 9>"${update_lockfile}" ||

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -718,17 +718,19 @@ EOF
 
   case "$architecture" in
     i386)
-      linux32 sudo DIST="${distribution:-}" ${ADT:+ADT=$ADT} \
+      linux32 sudo ${ADT:+ADT=$ADT} \
         cowbuilder --buildresult "$WORKSPACE"/binaries/ \
         --build $sourcefile \
+        --distribution="${distribution:-}" --architecture="${architecture:-}" \
         --basepath "${COWBUILDER_BASE}" --debbuildopts "${DEBBUILDOPTS:-}" \
         --hookdir "${PBUILDER_HOOKDIR}" --bindmounts "$BINDMOUNTS" --configfile="${pbuilderrc}"
       [ $? -eq 0 ] || bailout 1 "Error: Failed to build with cowbuilder."
       ;;
     amd64|all|*)
-      sudo DIST="${distribution:-}" ${ADT:+ADT=$ADT} \
+      sudo ${ADT:+ADT=$ADT} \
         cowbuilder --buildresult "$WORKSPACE"/binaries/ \
         --build $sourcefile \
+        --distribution="${distribution:-}" --architecture="${architecture:-}" \
         --basepath "${COWBUILDER_BASE}" --debbuildopts "${DEBBUILDOPTS:-}" \
         --hookdir "${PBUILDER_HOOKDIR}" --bindmounts "$BINDMOUNTS" --configfile="${pbuilderrc}"
       [ $? -eq 0 ] || bailout 1 "Error: Failed to build with cowbuilder."

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -718,7 +718,7 @@ EOF
 
   case "$architecture" in
     i386)
-      linux32 sudo DIST="${distribution:-}" ARCH="${architecture:-}" ${ADT:+ADT=$ADT} \
+      linux32 sudo DIST="${distribution:-}" ${ADT:+ADT=$ADT} \
         cowbuilder --buildresult "$WORKSPACE"/binaries/ \
         --build $sourcefile \
         --basepath "${COWBUILDER_BASE}" --debbuildopts "${DEBBUILDOPTS:-}" \
@@ -726,7 +726,7 @@ EOF
       [ $? -eq 0 ] || bailout 1 "Error: Failed to build with cowbuilder."
       ;;
     amd64|all|*)
-      sudo DIST="${distribution:-}" ARCH="${architecture:-}" ${ADT:+ADT=$ADT} \
+      sudo DIST="${distribution:-}" ${ADT:+ADT=$ADT} \
         cowbuilder --buildresult "$WORKSPACE"/binaries/ \
         --build $sourcefile \
         --basepath "${COWBUILDER_BASE}" --debbuildopts "${DEBBUILDOPTS:-}" \


### PR DESCRIPTION
Build of Redis package fails because ARCH is used in Makefile, with a
different meaning.
Removing it from cowbuilder allow Redis to be build and, as far as I saw,
does not break any other package.

Since use of ARCH with cowbuilder is optional, I found it safer just to remove
it from command line instead of changing more logic in build-and-provide script.
