### PR TITLE
Allow customization of generated timestamp in package version

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -106,3 +106,8 @@
 # Enable ccache (compiler cache for fast recompilation of C/C++ code)
 # to speed up builds.
 # USE_CCACHE=true
+
+# Specify the format (as accepted by the 'date' command) for the generated
+# build timestamp.
+# Default: %Y%m%d%H%M%S
+# TIMESTAMP_FORMAT="%Y%m%d%H%M%S"

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -85,7 +85,12 @@ version_information() {
     # $ORIG_VERSION+0~$TIMESTAMP.$BUILD_NUMBER~1.$GIT_ID
     # so the version is always increasing over time, no matter what
     INCREASED_VERSION=$(increase-version-number $ORIG_VERSION)
-    TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+    if [ -n "${TIMESTAMP_FORMAT:-}" ] ; then
+      echo "*** Using custom timestamp format as specified by TIMESTAMP_FORMAT ***"
+      TIMESTAMP="$(date -u +"$TIMESTAMP_FORMAT")"
+    else
+      TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+    fi
     BUILD_VERSION="${TIMESTAMP}.${BUILD_NUMBER}" # git-dch appends something like ~1.gbp5f433e then
 
     # we do NOT raise the version number, if we detect an unreleased version,

--- a/scripts/generate-svn-snapshot
+++ b/scripts/generate-svn-snapshot
@@ -95,7 +95,12 @@ build_snapshot() {
 
   DISTRIBUTION=$(dpkg-parsechangelog --count 1 | awk '/^Distribution/ {print $2}')
 
-  TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+  if [ -n "${TIMESTAMP_FORMAT:-}" ] ; then
+    echo "*** Using custom timestamp format as specified by TIMESTAMP_FORMAT ***"
+    TIMESTAMP="$(date -u +"$TIMESTAMP_FORMAT")"
+  else
+    TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
+  fi
 
   if [ "$DISTRIBUTION" = "UNRELEASED" ] ; then
     # we do NOT raise the version number, if we detect an unreleased version


### PR DESCRIPTION
I want to generate the timestamps in a slightly custom format using an ISO-8601-style 'T' character between the date and the time (although a upper-case letter is against best-practices) mainly for readability reasons.

As there was no way to pass some form of customization I just implemented one myself.
