### PR TITLE
Add an option for enforcing Git commit in package version

### DIFF
--- a/examples/debian_glue
+++ b/examples/debian_glue
@@ -106,3 +106,10 @@
 # Enable ccache (compiler cache for fast recompilation of C/C++ code)
 # to speed up builds.
 # USE_CCACHE=true
+
+# In case you are explicitly marking your new package version as "UNRELEASED"
+# inside the debian/changelog file, you may not get a package build version
+# number containing the SCM commit. Set this to 'true' in order to work around
+# this.
+# Default: false
+# UNRELEASED_APPEND_COMMIT=false

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -93,6 +93,13 @@ version_information() {
     if [ "$DISTRIBUTION" = "UNRELEASED" ] && dpkg --compare-versions "$ORIG_VERSION" lt "$INCREASED_VERSION" ; then
       echo "*** Not increasing version number as distribution is set to UNRELEASED ***"
       INCREASED_VERSION="$ORIG_VERSION"
+
+      if [ "${UNRELEASED_APPEND_COMMIT:-}" = "true" ]; then
+        # However, as we will use plain 'dch' for this, we still want to have
+        # the (short) GIT commit id inside the version...
+        echo "*** UNRELEASED_APPEND_COMMIT is set to 'true', manually appending GIT commit to version number ***"
+        BUILD_VERSION="${BUILD_VERSION}~${GIT_COMMIT:0:7}"
+      fi
       APPLY_VERSION_WORKAROUND=true
     fi
 


### PR DESCRIPTION
This applies only in cases where the debian/changelog is explicitly set to "UNRELEASED" which makes the generate-git-snapshot use plain 'dch' instead of 'gbp dch' or 'git-dch' which in turn passes the generated version string directly as the new package version.

This is implemented as an additional option to avoid breaking existing users which are just happy with the current behaviour.