### PR TITLE
Fix TAP format pep8_tap output

### DIFF
--- a/tap/pep8_tap
+++ b/tap/pep8_tap
@@ -67,7 +67,7 @@ class Issue
       'code' => @code,
       'source' => @source.join("\n"),
       'file' => @file
-    }) + '---'  # end of yaml
+    }) + '...'  # end of yaml
     return ("not ok #{counter} #{@firstline}\n  " + body.gsub("\n","\n  "))
   end
 end


### PR DESCRIPTION
According to TAPv13 spec, inline yaml documents need to end with '...', not '---'.