### PR TITLE
Fix permissions of keyring.gpg in D20releaserepo.

### DIFF
--- a/pbuilder-hookdir/D20releaserepo
+++ b/pbuilder-hookdir/D20releaserepo
@@ -21,6 +21,7 @@ if [ -d "$TMPAPT" ]; then
     echo "Using keyring for additional apt sources."
 
     cp "${TMPAPT}/keyring.gpg" /etc/apt/trusted.gpg.d
+    chmod 0644 /etc/apt/trusted.gpg.d/keyring.gpg
   fi
 
   if [ "$UPDATE_PKGLIST" = 1 ]; then


### PR DESCRIPTION
In pbuilder-hookdir/B20autopkgtest after keyring.gpg is copied to
/etc/apt/trusted.gpg.d/keyring.gpg it's only readable by root. Because stretch
uses the system user "_apt" to read this files this breaks installing packages
out of a custom repository.

This commit fix this issue by simply executing:
  chmod 0644 /etc/apt/trusted.gpg.d/keyring.gpg
after copy.