### PR TITLE
Add variable to change changelog path for git-dch

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -209,7 +209,7 @@ git_dch_auto() {
     dch -b --distribution=UNRELEASED --newversion=$VERSION_STRING -- \
       "SNAPSHOT autobuild for unreleased $ORIG_VERSION via jenkins-debian-glue."
   else
-    ${GBP_DCH} --auto $DCH_COMBINED_OPTS
+    ${GBP_DCH} --auto $DCH_COMBINED_OPTS $DCH_CHANGELOG_FILE
   fi
 }
 
@@ -234,7 +234,7 @@ identify_latest_change() {
   fi
 
   echo "Latest tag [${last_tag:-}] / merge [${last_merge:-}] seems to be $since"
-  ${GBP_DCH} -s "${since}" $DCH_COMBINED_OPTS
+  ${GBP_DCH} -s "${since}" $DCH_COMBINED_OPTS $DCH_CHANGELOG_FILE
 
   local NEW_VERSION=$(dpkg-parsechangelog | awk '/^Version: / {print $2}')
 

--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -209,7 +209,7 @@ git_dch_auto() {
     dch -b --distribution=UNRELEASED --newversion=$VERSION_STRING -- \
       "SNAPSHOT autobuild for unreleased $ORIG_VERSION via jenkins-debian-glue."
   else
-    ${GBP_DCH} --auto $DCH_COMBINED_OPTS $DCH_CHANGELOG_FILE
+    ${GBP_DCH} --auto $DCH_COMBINED_OPTS ${DCH_CHANGELOG_FILE:-}
   fi
 }
 
@@ -234,7 +234,7 @@ identify_latest_change() {
   fi
 
   echo "Latest tag [${last_tag:-}] / merge [${last_merge:-}] seems to be $since"
-  ${GBP_DCH} -s "${since}" $DCH_COMBINED_OPTS $DCH_CHANGELOG_FILE
+  ${GBP_DCH} -s "${since}" $DCH_COMBINED_OPTS ${DCH_CHANGELOG_FILE:-}
 
   local NEW_VERSION=$(dpkg-parsechangelog | awk '/^Version: / {print $2}')
 


### PR DESCRIPTION
In cases where the source package comes already with a debian folder which is located in some subfolder, it can be needed to specify the path to that file explicitly for git-dch to work correctly. That's why I introduced the variable "$DCH_CHANGELOG_FILE", so I could specify this file. It's empty and uninitialized if not specified, in which case the changelog is read from ./debian/changelog.

This commit should not break anything but make creation of packages from git repositories more flexible.