### PR TITLE
Adding SKIP_MISSING_BINARY_REMOVAL to prevent removal of binary pkg

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -811,8 +811,8 @@ remove_packages() {
 }
 
 remove_missing_binary_packages() {
-  if [ -n "${SKIP_REMOVAL:-}" ] ; then
-    echo "*** Skipping removal of existing packages as requested via SKIP_REMOVAL ***"
+  if [ -n "${SKIP_MISSING_BINARY_REMOVAL:-${SKIP_REMOVAL:-}}" ] ; then
+    echo "*** Skipping removal of existing packages as requested via SKIP_MISSING_BINARY_REMOVAL or SKIP_REMOVAL ***"
     return 0
   fi
 


### PR DESCRIPTION
Adding SKIP_MISSING_BINARY_REMOVAL to prevent removal of binary packages not belonging to the currently built source package.  Should help go around #139 