### PR TITLE
Fix building for different release distributions

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -648,10 +648,10 @@ cowbuilder_run() {
       local REPOSITORY="${REPOSITORY}/release/${release}"
     fi;
 
-    if [ -d "${REPOSITORY}/dists/${release}" ]; then
+    if [ -d "${REPOSITORY}/dists/${RELEASE_DISTRIBUTION}" ]; then
       BINDMOUNTS="$BINDMOUNTS $REPOSITORY"
       local components="$(awk -F': ' '/^Components:/ { print $2 }' \
-        "${REPOSITORY}/dists/${release}/Release")"
+        "${REPOSITORY}/dists/${RELEASE_DISTRIBUTION}/Release")"
       # Check if keyring is provided so the repository can be verified.
       if [ -n "${REPOSITORY_KEYRING:-}" ]; then
         local trusted=
@@ -662,7 +662,7 @@ cowbuilder_run() {
         local trusted="[trusted=yes]"
       fi
       cat > /tmp/apt-$$/release.list <<EOF
-deb ${trusted} file://${REPOSITORY} ${release} ${components}
+deb ${trusted} file://${REPOSITORY} ${RELEASE_DISTRIBUTION} ${components}
 EOF
     fi
 
@@ -1013,7 +1013,7 @@ release_repos() {
 
   if [ "${REMOVE_FROM_RELEASE:-}" = 'true' ]; then
     echo "*** REMOVE_FROM_RELEASE is set, trying to remove package(s) from release repository"
-    REPOS="${release}" remove_packages
+    REPOS="${RELEASE_DISTRIBUTION}" remove_packages
   fi
 
   # get rid of files that aren't mentioned in the changes files before copying to incoming directory
@@ -1052,7 +1052,7 @@ EOF
   cd "$old_dir"
 
   if [ $RC -ne 0 ] ; then
-    bailout 1 "Error: Failed to execute processincoming for release ${release}."
+    bailout 1 "Error: Failed to execute processincoming for release ${RELEASE_DISTRIBUTION}."
   fi
 }
 


### PR DESCRIPTION
(That should actually allow to close #92)

Tested with jenkins 2.2, reprepro 4.13.1 on Ubuntu 14.04:  versions of the to be processed files have to contain the target distribution, mainly controlled by setting the version in the debian/changelog, e.g., 0.1.0-1~trusty.
