### PR TITLE
take into account .udebs in remove_packages()

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -797,7 +797,7 @@ remove_packages() {
 
     if $skip ; then
       echo "*** Package '$binpackage' listed in SKIP_PACKAGE_FROM_REMOVAL - skipping removal therefore ***"
-    elif echo "$file" | egrep -q '_all.deb$'; then
+    elif echo "$file" | egrep -q '_all.u?deb$'; then
       # note: "removesrc" would remove foreign arch files (of different builds)
       echo "*** Removing existing package ${binpackage} from repository ${REPOS} (arch all) ***"
       ${SUDO_CMD:-} ${REPREPRO_CMD} -b "${REPOSITORY}" ${REPREPRO_OPTS} remove "${REPOS}" "${binpackage}"


### PR DESCRIPTION
When building for multiple architectures with axis, the main architecture axis is supposed to remove previous versions of the package from the repo for all architectures.
I found that the code handling this wasn't working properly for .udebs
Here is a fix, tested in production.