### PR TITLE
Don't override filter regexs

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -462,7 +462,7 @@ quilt_cleanup
 
 # build source package, run before switching back to previous branch
 # to get the actual requested version
-dpkg-buildpackage -uc -us -nc -d -S -i -I ${DBP_EXTRA_OPTS:-}
+dpkg-buildpackage -uc -us -nc -d -S ${DBP_EXTRA_OPTS:-}
 
 if [ -n "${KEY_ID:-}" ] ; then
   echo "*** Found environment variable KEY_ID, set to ${KEY_ID:-}, signing source package ***"


### PR DESCRIPTION
If you have a debian/source/options with specific filter regexs for
diffs and/or tarballs, using a blank '-i' or '-I' will override them and
use the defaults.