### PR TITLE
Pass -b option to dpkg-buildpackage

### DIFF
--- a/scripts/generate-git-snapshot
+++ b/scripts/generate-git-snapshot
@@ -462,7 +462,7 @@ quilt_cleanup
 
 # build source package, run before switching back to previous branch
 # to get the actual requested version
-dpkg-buildpackage -uc -us -nc -d -S ${DBP_EXTRA_OPTS:-}
+dpkg-buildpackage -b -uc -us -nc -d -S ${DBP_EXTRA_OPTS:-}
 
 if [ -n "${KEY_ID:-}" ] ; then
   echo "*** Found environment variable KEY_ID, set to ${KEY_ID:-}, signing source package ***"


### PR DESCRIPTION
This will prevent errors like

17:18:52 dpkg-source: error: aborting due to unexpected upstream changes, see /tmp/zuul_2.5.0-8-gcbc7f62-wmf4jessie1+0~20170219171846.692+jessie+wikimedia~1.gbpe6daa4.diff.RW7JQt
17:18:52 dpkg-source: info: you can integrate the local changes with dpkg-source --commit
17:18:52 dpkg-buildpackage: error: dpkg-source -i -I --unapply-patches -b source gave error exit status 2
17:18:52 Build step 'Execute shell' marked build as failure

See https://wiki.samat.org/CheatSheet/Debian and https://integration.wikimedia.org/ci/job/debian-glue-non-voting/692/console (Log will be deleted in 15-30 days)