### PR TITLE
spelling fix

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -129,7 +129,7 @@ checks_and_defaults() {
     FREIGHT_VARCACHE=${FREIGHT_BASE}/default
     FREIGHT_CONF=${FREIGHT_BASE}/default.conf
   else
-    # Default to /srv/freight unless specifed
+    # Default to /srv/freight unless specified
     if [ -z "${FREIGHT_BASE:-}" ] ; then
       FREIGHT_BASE=/srv/freight
     fi


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.