### PR TITLE
[piuparts_wrapper] don't use COMPONENTS environment variable

### DIFF
--- a/scripts/piuparts_wrapper
+++ b/scripts/piuparts_wrapper
@@ -57,15 +57,15 @@ create_base_tgz() {
     echo "*** Using mirror $MIRROR ***"
   fi
 
-  if [ -n "${COMPONENTS:-}" ] ; then
-    echo "*** COMPONENTS is set [$COMPONENTS], using for debootstrapping ***"
-    components="$COMPONENTS"
+  if [ -n "${PIUPARTS_COMPONENTS:-}" ] ; then
+    echo "*** PIUPARTS_COMPONENTS is set [${PIUPARTS_COMPONENTS}], using for debootstrapping ***"
+    components="${PIUPARTS_COMPONENTS}"
   elif lsb_release --id 2>/dev/null | grep -q Ubuntu ; then
     components='main,universe,restricted,multiverse'
     echo "*** Ubuntu detected, using components $components ***"
   else
     components='main,contrib,non-free'
-    echo "*** COMPONENTS is unset and looks like Debian - therefore using components $components ***"
+    echo "*** PIUPARTS_COMPONENTS is unset and looks like Debian - therefore using components $components ***"
   fi
 
   tmpdir=$(mktemp -d)


### PR DESCRIPTION
use PIPUPARTS_ prefix instead

* debootstrap uses COMPONENTS internally so exporting it was causing
  troubles like

> E: Invalid Release file, no entry for main,contrib,non-free/binary-amd64/Packages

Thanks to @dylan171 at #145 for that great bug report