### PR TITLE
Allow MIRRORSITE to pass sudo

### DIFF
--- a/puppet/jenkins_debian_glue.pp
+++ b/puppet/jenkins_debian_glue.pp
@@ -296,7 +296,7 @@ class jenkins::software {
 
 # Make sure DEB_* options reach cowbuilder, like e.g.:
 #  export DEB_BUILD_OPTIONS="parallel=8" /usr/bin/build-and-provide-package
-Defaults  env_keep+="DEB_* DIST ARCH ADT"
+Defaults  env_keep+="DEB_* DIST ARCH ADT MIRRORSITE"
 
 # for *-binaries job
 jenkins ALL=NOPASSWD: /usr/sbin/cowbuilder, /usr/sbin/chroot


### PR DESCRIPTION
cowbuilder always passes a --mirror.  When one system is used to build both Debian and Ubuntu packages, it is necessary to specify a MIRRORSITE for at least some of them.  This permits it to cross sudo.