### PR TITLE
Run lintian inside the build environement

### DIFF
--- a/pbuilder-hookdir/B90lintian
+++ b/pbuilder-hookdir/B90lintian
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Hook to run lintian inside the cowbuilder environment.
+#
+
+BUILDDIR="${BUILDDIR:-/tmp/buildd}"
+
+if [ "${LINTIAN:-}" != "true" ] ; then
+  echo "Skipping lintian (LINTIAN is not 'true')"
+  exit 0
+fi
+
+if [ -n "${LINTIAN_OPTIONS:-}" ] ; then
+  echo "*** Using provided LINTIAN_OPTIONS $LINTIAN_OPTIONS ***"
+fi
+
+set -ex -o pipefail
+apt-get -y "${APTGETOPT[@]}" install lintian
+lintian --version
+
+package_dir=$(cd "$BUILDDIR"/*/debian/.. 2>/dev/null && pwd -P)
+PACKAGE_NAME=$(basename "$package_dir")
+
+echo "Found package name: $PACKAGE_NAME"
+
+# Requires a .pbuilderrc with:
+#  export ADDITIONAL_BUILDRESULTS=(../*.lintian.txt)
+lintian_out=${BUILDDIR}/${PACKAGE_NAME}.lintian.txt
+su -c "lintian ${LINTIAN_OPTIONS:-} \"${BUILDDIR}\"/*.changes 2>&1 | tee \"${lintian_out}\"" - pbuilder \
+  || EXIT=$?
+# We strip ANSI sequences in case lintian got --color forced
+sed -i 's%\x1B\[[0-9;]*\?[mGKH]%%g' "${lintian_out}"
+
+case ${EXIT:-0} in
+  2)
+    echo "lintian run-time error."
+    exit 2
+    ;;
+  1|*)
+    exit 0
+    ;;
+esac

--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -138,6 +138,12 @@ checks_and_defaults() {
     FREIGHT_VARCACHE=${FREIGHT_BASE}/${FREIGHT_REPOSITORY}
     FREIGHT_CONF=${FREIGHT_BASE}/${FREIGHT_REPOSITORY}.conf
   fi
+
+  if [ "${LINTIAN:-}" = 'true' ] ; then
+    # Will run lintian and we need pbuilder to copy the result file to
+    # $BUILDRESULT.
+    ADDITIONAL_BUILDRESULTS+=('../*lintian.txt')
+  fi
 }
 
 clean_workspace() {

--- a/scripts/lintian-junit-report
+++ b/scripts/lintian-junit-report
@@ -37,6 +37,11 @@ o = OptionParser.new do|opts|
     lintian_file = f
   end
 
+  options[:skiplintian] = false
+  opts.on("--skip-lintian", String, "filename file will be processed") do
+    options[:skiplintian] = true
+  end
+
   options[:disableplaintext] = false
   opts.on('--disable-plaintext', 'Disable recording lintian output in lintian.txt' ) do
     options[:disableplaintext] = true
@@ -79,31 +84,35 @@ files = ARGV
 usage if files.empty?
 ### }}}
 
+if ! options[:skiplintian] then
 ### make sure lintian is available {{{
-if not system("which lintian >/dev/null 2>&1") then
-  $stderr.puts "Error: lintian not available."
-  exit(1)
-end
+  if not system("which lintian >/dev/null 2>&1") then
+    $stderr.puts "Error: lintian not available."
+    exit(1)
+  end
 # }}}
 
 ### run lintian {{{
-start = Time.now.to_f
+  start = Time.now.to_f
 
-lintian_options << "--info" unless options[:disablenotes]
+  lintian_options << "--info" unless options[:disablenotes]
 
-# Ruby 1.8's IO.popen expects a string instead of an array :(
-lintian_cmd = (['lintian'] + lintian_options + files).collect { |v| Shellwords.escape(v) }.join(" ")
-$output = IO.popen(lintian_cmd) do |io|
-  io.read
-end
+  # Ruby 1.8's IO.popen expects a string instead of an array :(
+  lintian_cmd = (['lintian'] + lintian_options + files).collect { |v| Shellwords.escape(v) }.join(" ")
+  $output = IO.popen(lintian_cmd) do |io|
+    io.read
+  end
 
-$duration = Time.now.to_f - start
+  $duration = Time.now.to_f - start
 
-if ! options[:disablenotes] then
-  File.open(lintian_file, 'w') {|f| f.write($output) }
-end
-
+  if ! options[:disablenotes] then
+    File.open(lintian_file, 'w') {|f| f.write($output) }
+  end
 ### }}}
+else
+  $duration = 0
+  $output = File.open(lintian_file, 'r').read
+end
 
 class JUnitOutput
   require 'rexml/formatters/transitive'


### PR DESCRIPTION
scripts/lintian-junit-report first runs lintian on the build host and
then post process the output to generate a JUnit file.

I have the use case to run lintian via a pbuilder hook to use the
lintian version that comes with the targetted distribution. The result
is a lintian.txt which I need to convert to JUnit.

Merge in e2beae591b from the lintian branch, that lets one skip running lintian
and instead process an existing lintian output.

Add a new pbuilder hook B90lintian based on the autopkgtest. By setting the
environment variable LINTIAN=true, the hook will: 
* install lintian
* run it against the package

pbuilder MUST have ADDITIONAL_BUILDRESULTS=(../*.lintian.txt). That would
export the lintian result out of the build environement to pbuilder buildresult
directory.  One can then process the file using something like:

for x in *.lintian.txt do; 
    echo "Converting lintian file $x" 
    /usr/bin/lintian-junit-report \
      --skip-lintian \
      --filename "$x" \
      *.changes > "${x/$suffix/.lintian.xml}"
done
