### PR TITLE
Fixes #195: Check if reprepro distribution exists

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -906,7 +906,10 @@ reprepro_wrapper() {
     bailout 1 "Error: repository ${REPOSITORY} does not exist."
   fi
 
-  ${SUDO_CMD:-} generate-reprepro-codename "${REPOS}"
+  if ! grep -q "^\(Codename\|Suite\): ${REPOS}$" "${REPOSITORY}"/conf/distributions ; then
+      echo "Distribution ${REPOS} does not exist in repository ${REPOSITORY}, generating now"
+      ${SUDO_CMD:-} generate-reprepro-codename "${REPOS}"
+  fi
 
   remove_packages
   remove_missing_binary_packages


### PR DESCRIPTION
Add a check in reprepro_wrapper to only invoke generate-reprepro-codename if it's not presently in the repository's distribution configuration.