### PR TITLE
piuparts_wrapper: ensure COMPONENTS variable is unset before invoking…

### DIFF
--- a/scripts/piuparts_wrapper
+++ b/scripts/piuparts_wrapper
@@ -67,6 +67,7 @@ create_base_tgz() {
     components='main,contrib,non-free'
     echo "*** COMPONENTS is unset and looks like Debian - therefore using components $components ***"
   fi
+  unset "COMPONENTS" # ensure it's unset so debootstrap doesn't fail, see GH issue 145
 
   tmpdir=$(mktemp -d)
 


### PR DESCRIPTION
… debootstrap

Debootstrap accesses the COMPONENTS variable (sigh) and fails hard if
it's set. To avoid failures on during debootstrap unset the variable.
This should be the easiest solution to fix the issue and not having to
break backwards compatibility.

Fixes https://github.com/mika/jenkins-debian-glue/issues/145