### PR TITLE
remove-reprepro-codename: also get rid of package indices files

### DIFF
--- a/scripts/remove-reprepro-codename
+++ b/scripts/remove-reprepro-codename
@@ -65,4 +65,7 @@ perl -i -00 -pe "if (!\$done && m|$codename|) { \$_=q(); \$done++}" "${REPOSITOR
 echo "*** Removing vanished data from reprepro ***"
 ${REPREPRO_CMD} $REPREPRO_OPTS -b "$REPOSITORY" --delete clearvanished
 
+echo "*** Removing package indices files (${REPOSITORY}/dists/${codename}) ***"
+rm -rf "${REPOSITORY}/dists/${codename}"
+
 # vim:foldmethod=marker ts=2 ft=sh ai expandtab sw=2


### PR DESCRIPTION
Quoting the "clearvanished" section of reprepro(1):

| Do not forget to remove all exported package indices manually"

If we don't manually remove them, files like those will persist:

| mprokop@jenkins2 /srv/mirror/autobuild/dists % find gerrit_TT53525_review27568
| gerrit_TT53525_review27568
| gerrit_TT53525_review27568/Release
| gerrit_TT53525_review27568/Release.gpg
| gerrit_TT53525_review27568/InRelease
| gerrit_TT53525_review27568/main
| gerrit_TT53525_review27568/main/source
| gerrit_TT53525_review27568/main/source/Release
| gerrit_TT53525_review27568/main/source/Sources.gz
| gerrit_TT53525_review27568/main/debian-installer
| gerrit_TT53525_review27568/main/debian-installer/binary-i386
| gerrit_TT53525_review27568/main/debian-installer/binary-i386/Packages
| gerrit_TT53525_review27568/main/debian-installer/binary-i386/Packages.gz
| gerrit_TT53525_review27568/main/debian-installer/binary-amd64
| gerrit_TT53525_review27568/main/debian-installer/binary-amd64/Packages
| gerrit_TT53525_review27568/main/debian-installer/binary-amd64/Packages.gz
| gerrit_TT53525_review27568/main/binary-i386
| gerrit_TT53525_review27568/main/binary-i386/Release
| gerrit_TT53525_review27568/main/binary-i386/Packages
| gerrit_TT53525_review27568/main/binary-i386/Packages.gz
| gerrit_TT53525_review27568/main/binary-amd64
| gerrit_TT53525_review27568/main/binary-amd64/Release
| gerrit_TT53525_review27568/main/binary-amd64/Packages
| gerrit_TT53525_review27568/main/binary-amd64/Packages.gz

Development sponsored by Sipwise GmbH, recorded as
TT#53758 in customers' ticket system.