### PR TITLE
Remove usage of SUDO_CMD from generate-reprepro-codename

### DIFF
--- a/scripts/generate-reprepro-codename
+++ b/scripts/generate-reprepro-codename
@@ -119,12 +119,12 @@ if [ -z "${REPOSITORY:-}" ] ; then
   echo "*** Repository variable REPOSITORY is unset, using default [$REPOSITORY] ***"
 fi
 
-if ! ${SUDO_CMD:-} mkdir -p "${REPOSITORY}"/conf ; then
+if ! mkdir -p "${REPOSITORY}"/conf ; then
   echo "Error creating ${REPOSITORY}/conf (forgot to create ${REPOSITORY} and chown jenkins?)" >&2
   exit 1
 fi
 
-if ! ${SUDO_CMD:-} chown $(id -un) "${REPOSITORY}"/conf ; then
+if ! chown $(id -un) "${REPOSITORY}"/conf ; then
   echo "*** Warning: failed to adjust permissions of ${REPOSITORY}/conf ***"
   echo "*** This might be caused by a remote FS like sshfs, so not failing the build. ***"
   echo "*** Please fix the underlying problem if you depend on according permissions. ***"


### PR DESCRIPTION
The script generate-reprepro-codename is already called by SUDO_CMD (so,
as the reprepro user if necessary) from build-and-provide-package.

Fixes #220