### PR TITLE
build-and-provide-package: fix debian/control lookup for non-native pkgs

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -513,9 +513,10 @@ identify_build_type() {
   local old_dir=$(pwd)
   cd "$TMPDIR"
   for file in  ${BASE_PATH}/${SOURCE_PACKAGE}_*.tar.* ; do
-    if tar atf "$file" 2>/dev/null | egrep -q '^[^/]+/debian/control$' ; then
+    if tar atf "$file" 2>/dev/null | egrep -q '^([^/]+/)?debian/control$' ; then
       # might be source/debian/control - so let's identify the path to debian/control
-      local control_file=$(tar atf "$file" 2>/dev/null | egrep '^[^/]+/debian/control$')
+      # This assumes that no one will put `debian/debian/control` in debian tarball.
+      local control_file=$(tar atf "$file" 2>/dev/null | egrep '^([^/]+/)?debian/control$')
       tar axf "$file" "$control_file" || bailout 1 "Error while looking at debian/control in source archive."
 
       if grep -q '^Architecture: all' "$control_file" ; then


### PR DESCRIPTION
Commit 5d465bf537f38a083de61d6ff1815c9044cef352 (build-and-provide-
package: Look only for the "real" debian/control file) fixes debian/
control lookup for native packages with multiple debian/control files.
However, it completely breaks the non-native case, as the regex always
expect 1 level of subdirectory.

This commit edit the regex to make the 1 level of subdirectory part
optional. This make it works on both native and non-native packages.

This has been tested on the original offending package (autopkgtest) to
make sure no regression occurs.