### PR TITLE
Switch from deprecated /var/run to /run

### DIFF
--- a/scripts/build-and-provide-package
+++ b/scripts/build-and-provide-package
@@ -288,7 +288,7 @@ dist_and_arch_settings() {
     echo "*** No COWBUILDER_BASE set, using $COWBUILDER_BASE as cowbuilder base.cow ***"
   fi
 
-  local lockfiles="/var/run/lock/${COWBUILDER_DIST}-${arch}"
+  local lockfiles="/run/lock/${COWBUILDER_DIST}-${arch}"
   build_lockfile="${lockfiles}.building.$$"
   update_lockfile="${lockfiles}.update"
   update_lockfile_pid="${lockfiles}.update.$$"


### PR DESCRIPTION
FHS 3.0 deprecates the use of /var/run, and specifies to use /run instead. Most distributions have done this switch already.

Ref: https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#varrunRuntimeVariableData
TT#51701 in customers' ticket system.