### PR TITLE
lintian-junit-report: fix for xunit 2.x Jenkins plugin

### DIFF
--- a/scripts/lintian-junit-report
+++ b/scripts/lintian-junit-report
@@ -4,6 +4,9 @@
 # Notes:
 # * for JUnit spec details see http://windyroad.org/dl/Open%20Source/JUnit.xsd
 #
+# This is loosely based on PHPUnit 4.x JUnit output an XSD for it can be found
+# at https://github.com/jenkinsci/xunit-plugin
+#
 # Ideas:
 # * integrate within Jenkins plugin (using jruby)
 # * integrate in Violations plugin (for further reporting options)
@@ -124,7 +127,7 @@ class JUnitOutput
     @document << REXML::XMLDecl::new
     @failures = 0
     @skipped = 0
-    @suite = @document.add_element 'testsuite', {'time' => duration}
+    @suite = @document.add_element 'testsuite', {'time' => duration, 'name' => 'lintian'}
   end
 
   def add_case(package, tag)


### PR DESCRIPTION
When using the Jenkins Xunit plugin, the generated XML lintian report
does not validate the plugin embeded XSD:

  Attribute 'name' must appear on element 'testsuite'.

The reporter has been made to mostly mimic the phpunit output but missed
the namel attribute. Add a dummy 'lintian' name to the testsuite
element.

The Jenkins plugin has to be configured to use phpunit-4.0.

One can then validate it using the embedded XSD:

 scripts/lintian-junit-report foo.dsc > lintian.xml
 git clone https://github.com/jenkinsci/xunit-plugin
 xmlllint --noout \
  --schema ./xunit-plugin/src/main/resources/org/jenkinsci/plugins/xunit/types/phpunit-4.0.xsd \
  lintian.xml

Add a note refering to the XSD provided by Jenkins.

Reference:
https://phabricator.wikimedia.org/T194096#6172999