### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,7 +75,7 @@ Replaces:
 Recommends:
  curl,
  libperl-critic-perl,
- pep8 (>= 1.4.6~),
+ pep8,
  qemu-user-static,
  shellcheck,
 Description: Jenkins Debian glue scripts - dependency package


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/jenkins-debian-glue/1fd14e01-9406-4816-8016-897c7e15e901.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*jenkins-debian-glue\*\*
### Control files of package jenkins-debian-glue-buildenv: lines which differ (wdiff format)
* Recommends: curl, libperl-critic-perl, [-pep8 (>= 1.4.6~),-] {+pep8,+} qemu-user-static, shellcheck


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1fd14e01-9406-4816-8016-897c7e15e901/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1fd14e01-9406-4816-8016-897c7e15e901/diffoscope)).
