### PR TITLE
[generate-git-snapshot] Allow to disable pre cleanup

### DIFF
--- a/scripts/jdg-generate-git-snapshot
+++ b/scripts/jdg-generate-git-snapshot
@@ -435,7 +435,12 @@ source_format_opts() {
 
 # main execution
 echo "*** source package build phase ***"
-rm -f ./* || true
+
+if [ -n "${SKIP_PRE_CLEANUP:-}" ] ; then
+  echo '*** SKIP_PRE_CLEANUP is set ***'
+else
+  rm -f ./* || true
+fi
 
 if [ -n "${PRE_SOURCE_HOOK:-}" ] ; then
   echo "*** Found environment variable PRE_SOURCE_HOOK, set to ${PRE_SOURCE_HOOK:-} ***"


### PR DESCRIPTION
This adds option to disable pre-cleanup in generate-git-snapshot

The use case for this is if we want to build quilt packages that need extra tarballs (orig for example) in the parent directory of $SOURCE_DIRECTORY.