### PR TITLE
tap: fix missing disable-mergecheck option on getopt

### DIFF
--- a/tap/jdg-tap-tool-dispatcher
+++ b/tap/jdg-tap-tool-dispatcher
@@ -5,7 +5,7 @@ set -u
 BASE_BIN=${BASE_BIN:-/usr/bin}
 
 # command line handling
-CMDLINE_OPTS=disable-checkbashism,disable-pep8,disable-perlcritic,disable-shellcheck
+CMDLINE_OPTS=disable-checkbashism,disable-pep8,disable-perlcritic,disable-shellcheck,disable-mergecheck
 CMDLINE_OPTS+=,file-list,help
 
 _opt_temp=$(getopt --name jdg-tap-tool-dispatcher -o -f+h --long $CMDLINE_OPTS -- "$@")


### PR DESCRIPTION
bug introduced at f1caf363e393a8bda400d64b812306b294b01172