### PR TITLE
MT#60337 tap: [merge-conflict] skip directory arguments

### DIFF
--- a/tap/jdg-tap-merge-conflict
+++ b/tap/jdg-tap-merge-conflict
@@ -12,7 +12,10 @@ end
 
 file = ARGV[0]
 
-if not File.exists? file
+if File.directory? file
+  $stderr.puts "#{file} is a directory. Ignoring."
+  exit 0
+elsif not File.exists? file
   $stderr.puts "Error: file #{file} could not be read."
   exit 1
 end

--- a/tests/merge-conflict
+++ b/tests/merge-conflict
@@ -19,6 +19,11 @@ testPass()
   assertEquals "$($SCRIPT $OK_FILE)" ""
 }
 
+testDir()
+{
+  assertEquals "$($SCRIPT /tmp 2>&1)" "/tmp is a directory. Ignoring."
+}
+
 . /usr/share/shunit2/shunit2
 
 # vim:foldmethod=marker ts=2 ft=sh ai expandtab sw=2


### PR DESCRIPTION
fix error when passing a directory instead of a file

> 1..1
> not ok 1           grep: source/kamailio_config_tests/scenarios_lnp/templates: Is a directory
